### PR TITLE
Added `include_in_NERC_total_invoice` field to `institute_list.yaml`

### DIFF
--- a/process_report/institute_list.yaml
+++ b/process_report/institute_list.yaml
@@ -6,12 +6,14 @@
     domains:
     - bu.edu
     mghpcc_partnership_start_date: "2013-06"
+    include_in_nerc_total_invoice: True
 -   display_name: Bentley
     domains:
     - bentley.edu
 -   display_name: University of Rhode Island
     domains:
     - uri.edu
+    include_in_nerc_total_invoice: True
 -   display_name: Red Hat
     domains:
     - redhat.com
@@ -38,6 +40,7 @@
     - harvard.edu
     - chemistry.harvard.edu
     mghpcc_partnership_start_date: "2013-06"
+    include_in_NERC_total_invoice: True
 -   display_name: Worcester Polytechnic Institute
     domains:
     - wpi.edu

--- a/process_report/invoices/NERC_total_invoice.py
+++ b/process_report/invoices/NERC_total_invoice.py
@@ -12,12 +12,6 @@ class NERCTotalInvoice(invoice.Invoice):
     - NewPICreditProcessor
     """
 
-    INCLUDED_INSTITUTIONS = [
-        "Harvard University",
-        "Boston University",
-        "University of Rhode Island",
-    ]
-
     export_columns_list = [
         invoice.INVOICE_DATE_FIELD,
         invoice.PROJECT_FIELD,
@@ -59,10 +53,16 @@ class NERCTotalInvoice(invoice.Invoice):
             if data:
                 return str.lower(data)
 
+        included_institutions = list()
+        institute_list = util.load_institute_list()
+        for institute_info in institute_list:
+            if institute_info.get("include_in_nerc_total_invoice"):
+                included_institutions.append(institute_info["display_name"])
+
         self.export_data = self.data[
             self.data[invoice.IS_BILLABLE_FIELD] & ~self.data[invoice.MISSING_PI_FIELD]
         ]
         self.export_data = self.export_data[
-            self.export_data[invoice.INSTITUTION_FIELD].isin(self.INCLUDED_INSTITUTIONS)
+            self.export_data[invoice.INSTITUTION_FIELD].isin(included_institutions)
             | (self.export_data[invoice.GROUP_MANAGED_FIELD].apply(_lower_col) == "yes")
         ]


### PR DESCRIPTION
Closes #138  The means the `INCLUDED_INSTITUTIONS` from `NERCTotalInvoice` is now removed.