### PR TITLE
Convert prepay managed field into Boolean

### DIFF
--- a/process_report/invoices/NERC_total_invoice.py
+++ b/process_report/invoices/NERC_total_invoice.py
@@ -49,10 +49,6 @@ class NERCTotalInvoice(invoice.Invoice):
         return f"Invoices/{self.invoice_month}/Archive/NERC-{self.invoice_month}-Total-Invoice {util.get_iso8601_time()}.csv"
 
     def _prepare_export(self):
-        def _lower_col(data):
-            if data:
-                return str.lower(data)
-
         included_institutions = list()
         institute_list = util.load_institute_list()
         for institute_info in institute_list:
@@ -64,5 +60,5 @@ class NERCTotalInvoice(invoice.Invoice):
         ]
         self.export_data = self.export_data[
             self.export_data[invoice.INSTITUTION_FIELD].isin(included_institutions)
-            | (self.export_data[invoice.GROUP_MANAGED_FIELD].apply(_lower_col) == "yes")
+            | self.export_data[invoice.GROUP_MANAGED_FIELD]
         ]

--- a/process_report/processors/prepayment_processor.py
+++ b/process_report/processors/prepayment_processor.py
@@ -69,9 +69,9 @@ class PrepaymentProcessor(discount_processor.DiscountProcessor):
             prepay_group_dict[group_name][
                 invoice.PREPAY_GROUP_CONTACT_FIELD
             ] = group_info[invoice.PREPAY_GROUP_CONTACT_FIELD]
-            prepay_group_dict[group_name][invoice.PREPAY_MANAGED_FIELD] = group_info[
-                invoice.PREPAY_MANAGED_FIELD
-            ]
+            prepay_group_dict[group_name][invoice.PREPAY_MANAGED_FIELD] = (
+                group_info[invoice.PREPAY_MANAGED_FIELD].lower() == "yes"
+            )
             prepay_group_dict[group_name][invoice.GROUP_BALANCE_FIELD] = 0
             prepay_group_dict[group_name][invoice.PREPAY_PROJECT_FIELD] = []
 

--- a/process_report/tests/unit/processors/test_prepayment_processor.py
+++ b/process_report/tests/unit/processors/test_prepayment_processor.py
@@ -104,7 +104,7 @@ class TestPrepaymentProcessor(TestCase):
             ["G1"], ["P1"], ["2024-09"], ["2024-12"]
         )
         test_prepay_contacts = self._get_test_prepay_contacts(
-            ["G1"], ["G1@bu.edu"], [True]
+            ["G1"], ["G1@bu.edu"], ["Yes"]
         )
 
         answer_invoice = test_invoice.copy()
@@ -159,7 +159,7 @@ class TestPrepaymentProcessor(TestCase):
             ["G1", "G1"], project_names, ["2024-08", "2024-10"], ["2024-12", "2025-02"]
         )
         test_prepay_contacts = self._get_test_prepay_contacts(
-            ["G1"], ["G1@bu.edu"], [True]
+            ["G1"], ["G1@bu.edu"], ["Yes"]
         )
 
         answer_invoice = test_invoice.copy()
@@ -278,7 +278,7 @@ class TestPrepaymentProcessor(TestCase):
             ["G1", "G1"], project_names, ["2024-08", "2024-08"], ["2024-10", "2025-02"]
         )
         test_prepay_contacts = self._get_test_prepay_contacts(
-            ["G1"], ["G1@bu.edu"], [True]
+            ["G1"], ["G1@bu.edu"], ["Yes"]
         )
 
         answer_invoice = test_invoice.copy()
@@ -347,7 +347,7 @@ class TestPrepaymentProcessor(TestCase):
             ["G1", "G2"], project_names, ["2024-01", "2024-01"], ["2024-12", "2024-12"]
         )
         test_prepay_contacts = self._get_test_prepay_contacts(
-            ["G1", "G2"], ["G1@bu.edu", "G2@harvard.edu"], [True, False]
+            ["G1", "G2"], ["G1@bu.edu", "G2@harvard.edu"], ["Yes", "No"]
         )
 
         answer_invoice = test_invoice.copy()


### PR DESCRIPTION
In the prepay contacts csv, the `MGHPCC Managed` field contains a "Yes" or "No" string, and would be loaded as a string by `pandas.load_csv`. Previously, the `MOCA_prepaid_invoice` [incorrectly assumed](https://github.com/CCI-MOC/invoicing/blob/9ce1ab292df40fb75f2099de86b89fd8683b445e/process_report/invoices/MOCA_prepaid_invoice.py#L41) the `GROUP_MANAGED_FIELD` was a boolean, leading to a bug in billing. 

Fortunately, we don't have any prepay projects yet, so the impact of this is 0 (other than people's review time (I'm sorry)).

The prepay test case has been updated.