### PR TITLE
Fixed a bug where the MOCA prepay invoice did not assign `self.export…

### DIFF
--- a/process_report/invoices/MOCA_prepaid_invoice.py
+++ b/process_report/invoices/MOCA_prepaid_invoice.py
@@ -38,4 +38,4 @@ class MOCAPrepaidInvoice(invoice.Invoice):
         return f"Invoices/{self.invoice_month}/Archive/MOCA-A_Prepaid_Groups-{self.invoice_month}-Invoice {util.get_iso8601_time()}.csv"
 
     def _prepare_export(self):
-        self.data = self.data[self.data[invoice.GROUP_MANAGED_FIELD] == False]  # noqa: E712
+        self.export_data = self.data[self.data[invoice.GROUP_MANAGED_FIELD] == False]  # noqa: E712


### PR DESCRIPTION
Because `self.export_data` was not assigned, the prepay invoice simply could not be created.
This must have been something I missed while rebasing one of our PRs in the past. 