### PR TITLE
Implemented processor to fetch Coldfront allocation data

### DIFF
--- a/process_report/processors/coldfront_fetch_processor.py
+++ b/process_report/processors/coldfront_fetch_processor.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import functools
+import logging
+from dataclasses import dataclass
+
+import requests
+
+from process_report.invoices import invoice
+from process_report.processors import processor
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+CF_ATTR_ALLOCATED_PROJECT_NAME = "Allocated Project Name"
+
+
+@dataclass
+class ColdfrontFetchProcessor(processor.Processor):
+    nonbillable_projects: list[str]
+
+    @functools.cached_property
+    def coldfront_client(self):
+        keycloak_url = os.environ.get("KEYCLOAK_URL", "https://keycloak.mss.mghpcc.org")
+
+        # Authenticate with Keycloak
+        token_url = f"{keycloak_url}/auth/realms/mss/protocol/openid-connect/token"
+        r = requests.post(
+            token_url,
+            data={"grant_type": "client_credentials"},
+            auth=requests.auth.HTTPBasicAuth(
+                os.environ["KEYCLOAK_CLIENT_ID"],
+                os.environ["KEYCLOAK_CLIENT_SECRET"],
+            ),
+        )
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            sys.exit(f"Keycloak authentication failed:\n{r.status_code} {r.text}")
+
+        client_token = r.json()["access_token"]
+
+        session = requests.session()
+        headers = {
+            "Authorization": f"Bearer {client_token}",
+            "Content-Type": "application/json",
+        }
+        session.headers.update(headers)
+        return session
+
+    def _get_project_list(self):
+        return self.data[invoice.PROJECT_FIELD].unique()
+
+    def _fetch_coldfront_allocation_api(self, allocation_list):
+        coldfront_api_url = os.environ.get(
+            "COLDFRONT_URL", "https://coldfront.mss.mghpcc.org/api/allocations"
+        )
+        api_query_str = "&".join(
+            [
+                f"attr_{CF_ATTR_ALLOCATED_PROJECT_NAME}={project}"
+                for project in allocation_list
+            ]
+        )
+        r = self.coldfront_client.get(f"{coldfront_api_url}?{api_query_str}")
+
+        return r.json()
+
+    def _get_allocation_data(self, coldfront_api_data):
+        allocation_data = {}
+        for project, project_dict in coldfront_api_data.items():
+            allocation_data[project] = {
+                invoice.PI_FIELD: project_dict["project"]["pi"],
+                invoice.INSTITUTION_ID_FIELD: project_dict["attributes"][
+                    "Institution-Specific Code"
+                ],
+            }
+        return allocation_data
+
+    def _validate_allocation_data(self, allocation_data):
+        missing_projects = (
+            set(self._get_project_list())
+            - set(allocation_data.keys())
+            - set(self.nonbillable_projects)
+        )
+        missing_projects = list(missing_projects)
+        missing_projects.sort()  # Ensures order for testing purposes
+        if missing_projects:
+            logger.warning(
+                f"Projects {missing_projects} not found in Coldfront and are billable! Please check the project names"
+            )
+
+    def _apply_allocation_data(self, allocation_data):
+        for project, data in allocation_data.items():
+            mask = self.data[invoice.PROJECT_FIELD] == project
+            self.data.loc[mask, invoice.PI_FIELD] = data[invoice.PI_FIELD]
+            self.data.loc[mask, invoice.INSTITUTION_ID_FIELD] = data[
+                invoice.INSTITUTION_ID_FIELD
+            ]
+
+    def _process(self):
+        project_allocations_list = self._get_project_list()
+        api_data = self._fetch_coldfront_allocation_api(project_allocations_list)
+        allocation_data = self._get_allocation_data(api_data)
+        self._validate_allocation_data(allocation_data)
+        self._apply_allocation_data(allocation_data)

--- a/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
+++ b/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
@@ -1,0 +1,92 @@
+from unittest import TestCase, mock
+import pandas
+
+from process_report.tests import util as test_utils
+
+
+class TestColdfrontFetchProcessor(TestCase):
+    def _get_test_invoice(
+        self,
+        project,
+        pi=None,
+        institute_code=None,
+    ):
+        if not pi:
+            pi = [""] * len(project)
+
+        if not institute_code:
+            institute_code = [""] * len(project)
+
+        return pandas.DataFrame(
+            {
+                "Manager (PI)": pi,
+                "Project - Allocation": project,
+                "Institution - Specific Code": institute_code,
+            }
+        )
+
+    def _get_mock_allocation_data(self, project_list, pi_list, institute_code_list):
+        mock_data = {}
+        for i, project in enumerate(project_list):
+            mock_data[project] = {}
+            mock_data[project]["project"] = {"pi": pi_list[i]}
+            mock_data[project]["attributes"] = {
+                "Institution-Specific Code": institute_code_list[i]
+            }
+
+        return mock_data
+
+    @mock.patch(
+        "process_report.processors.coldfront_fetch_processor.ColdfrontFetchProcessor._fetch_coldfront_allocation_api",
+    )
+    def test_coldfront_fetch(self, mock_get_allocation_data):
+        mock_get_allocation_data.return_value = self._get_mock_allocation_data(
+            ["P1", "P2", "P3", "P4"],
+            ["PI1", "PI1", "", "PI12"],
+            ["IC1", "", "", "IC2"],
+        )
+        test_invoice = self._get_test_invoice(["P1", "P1", "P2", "P3", "P4"])
+        answer_invoice = self._get_test_invoice(
+            ["P1", "P1", "P2", "P3", "P4"],
+            ["PI1", "PI1", "PI1", "", "PI12"],
+            ["IC1", "IC1", "", "", "IC2"],
+        )
+        test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
+            data=test_invoice
+        )
+        test_coldfront_fetch_proc.process()
+        output_invoice = test_coldfront_fetch_proc.data
+        self.assertTrue(output_invoice.equals(answer_invoice))
+
+    @mock.patch(
+        "process_report.processors.coldfront_fetch_processor.ColdfrontFetchProcessor._fetch_coldfront_allocation_api",
+    )
+    def test_coldfront_project_not_found(self, mock_get_allocation_data):
+        """What happens when an invoice project is not found in Coldfront."""
+        mock_get_allocation_data.return_value = self._get_mock_allocation_data(
+            ["P1", "P2"],
+            ["PI1", "PI1"],
+            ["IC1", "IC2"],
+        )
+        test_nonbillable_projects = ["P3"]
+        test_invoice = self._get_test_invoice(["P1", "P2", "P3", "P4", "P5"])
+        answer_project_set = ["P4", "P5"]
+        test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
+            data=test_invoice, nonbillable_projects=test_nonbillable_projects
+        )
+
+        with self.assertLogs() as log:
+            test_coldfront_fetch_proc.process()
+            self.assertIn(
+                f"Projects {answer_project_set} not found in Coldfront and are billable! Please check the project names",
+                log.output[0],
+            )
+
+    @mock.patch("requests.sessions.Session.get")
+    def test_query_url(self, mock_request_get):
+        test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor()
+        test_coldfront_fetch_proc.coldfront_client = mock.MagicMock()
+        test_coldfront_fetch_proc._fetch_coldfront_allocation_api(["P1", "P2"])
+        test_coldfront_fetch_proc.coldfront_client.get.assert_called_with(
+            "https://coldfront.mss.mghpcc.org/api/allocations?attr_Allocated Project Name=P1&attr_Allocated Project Name=P2"
+        )

--- a/process_report/tests/unit/test_util.py
+++ b/process_report/tests/unit/test_util.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 import tempfile
 import pandas
 import os
@@ -104,3 +104,16 @@ class TestTimedProjects(TestCase):
 
         expected_projects = ["ProjectB", "ProjectC", "ProjectD"]
         self.assertEqual(excluded_projects, expected_projects)
+
+
+class TestValidateRequiredEnvVars(TestCase):
+    @mock.patch.dict(
+        "os.environ", {"KEYCLOAK_CLIENT_ID": "test", "KEYCLOAK_CLIENT_SECRET": "test"}
+    )
+    def test_env_vars_valid(self):
+        process_report.validate_required_env_vars()
+
+    @mock.patch.dict("os.environ", {"KEYCLOAK_CLIENT_ID": "test"})
+    def test_env_vars_missing(self):
+        with self.assertRaises(SystemExit):
+            process_report.validate_required_env_vars()

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -8,6 +8,7 @@ from process_report.invoices import (
 )
 
 from process_report.processors import (
+    coldfront_fetch_processor,
     add_institution_processor,
     validate_pi_alias_processor,
     lenovo_processor,
@@ -63,6 +64,21 @@ def new_pi_specific_invoice(
         name,
         invoice_month,
         data,
+    )
+
+
+def new_coldfront_fetch_processor(
+    name="",
+    invoice_month="0000-00",
+    data=None,
+    nonbillable_projects=None,
+):
+    if data is None:
+        data = pandas.DataFrame()
+    if nonbillable_projects is None:
+        nonbillable_projects = []
+    return coldfront_fetch_processor.ColdfrontFetchProcessor(
+        name, invoice_month, data, nonbillable_projects
     )
 
 


### PR DESCRIPTION
Closes #153. Authentication to Coldfront must be done through Keycloak by providing the client id and secret. These can be set through env vars (`KEYCLOAK_CLIENT_ID` and `KEYCLOAK_CLIENT_SECRET`). A Keycloak and Coldfront url can optionally be provided. They default to the ones hosted by the MGHPCC.

The processor is responsible for adding the PI email and institute code to invoices.
If a Coldfront allocation for an invoice project could not be found, and this project also happens to be
billable, a warning will be logged.

**The query to the Coldfront allocation API will only ask for allocations that appeared on the invoice**

Test cases have been added.