### PR TITLE
Fix temporary file unit test errors

### DIFF
--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -110,6 +110,7 @@ class TestNewPICreditProcessor(TestCase):
         self.test_old_pi_file = tempfile.NamedTemporaryFile(
             delete=False, mode="w+", suffix=".csv"
         )
+        self.test_old_pi_file.close()
 
     def tearDown(self) -> None:
         os.remove(self.test_old_pi_file.name)

--- a/process_report/tests/unit/processors/test_prepayment_processor.py
+++ b/process_report/tests/unit/processors/test_prepayment_processor.py
@@ -89,6 +89,7 @@ class TestPrepaymentProcessor(TestCase):
         self.test_prepay_debits_file = tempfile.NamedTemporaryFile(
             delete=False, mode="w+", suffix=".csv"
         )
+        self.test_prepay_debits_file.close()
 
     def tearDown(self) -> None:
         os.remove(self.test_prepay_debits_file.name)

--- a/process_report/tests/unit/test_institute_list_validate.py
+++ b/process_report/tests/unit/test_institute_list_validate.py
@@ -20,7 +20,7 @@ class TestInstituteListValidate(TestCase):
             },
         ]
 
-        with tempfile.NamedTemporaryFile(mode="w") as f:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             yaml.dump(test_institute_list, f)
             f.flush()
             main(["--github", f.name])
@@ -35,7 +35,7 @@ class TestInstituteListValidate(TestCase):
             }
         ]
 
-        with tempfile.NamedTemporaryFile(mode="w") as f:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             yaml.dump(test_institute_list, f)
             f.flush()
             with self.assertRaises(SystemExit):


### PR DESCRIPTION
Fixing of temp file errors within unit tests. Ensure proper closing and access to temp files for any OS that lock files by default (this prevents any process from opening it for reading while the file is open). Should allow for unit tests to run on more machines while maintaining original function. 

