### PR TITLE
update CI python version to 3.12 and specify python version in precommit.yaml

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+          python-version: '3.12'
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validate-institute-list.yaml
+++ b/.github/workflows/validate-institute-list.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
update CI files to python version 3.12 to accommodate changes in get_value_at from nerc-rates