### PR TITLE
Refactor: Force all configurations to be fetched from `settings.py`

### DIFF
--- a/process_report/invoices/pi_specific_invoice.py
+++ b/process_report/invoices/pi_specific_invoice.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from dataclasses import dataclass
 import subprocess
 import tempfile
@@ -10,10 +9,10 @@ from jinja2 import Environment, FileSystemLoader
 
 import process_report.invoices.invoice as invoice
 import process_report.util as util
+from process_report.settings import invoice_settings
 
 
 TEMPLATE_DIR_PATH = "process_report/templates"
-CHROME_BIN_PATH = os.environ.get("CHROME_BIN_PATH", "/usr/bin/chromium")
 
 
 logger = logging.getLogger(__name__)
@@ -134,17 +133,12 @@ class PIInvoice(invoice.Invoice):
             temp_fd.flush()
 
         def _create_pdf_invoice(temp_fd_name):
-            if not os.path.exists(CHROME_BIN_PATH):
-                sys.exit(
-                    f"Chrome binary does not exist at {CHROME_BIN_PATH}. Make sure the env var CHROME_BIN_PATH is set correctly and that Google Chrome is installed"
-                )
-
             invoice_pdf_path = (
                 f"{self.name}/{pi_instituition}_{pi}_{self.invoice_month}.pdf"
             )
             subprocess.run(
                 [
-                    CHROME_BIN_PATH,
+                    invoice_settings.chrome_bin_path,
                     "--headless",
                     "--no-sandbox",
                     f"--print-to-pdf={invoice_pdf_path}",

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -1,6 +1,4 @@
-import sys
 import logging
-import os
 
 import pandas
 import pyarrow
@@ -43,19 +41,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def validate_required_env_vars(required_env_vars):
-    for required_env_var in required_env_vars:
-        if required_env_var not in os.environ:
-            sys.exit(f"Required environment variable {required_env_var} is not set")
-
-
 def main():
-    """Remove non-billable PIs and projects"""
-    required_env_vars = []
-    if not invoice_settings.coldfront_api_filepath:
-        required_env_vars.extend(["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"])
-    validate_required_env_vars(required_env_vars)
-
     invoice_month = invoice_settings.invoice_month
 
     merged_dataframe = merge_csv(loader.get_csv_invoice_filepath_list())

--- a/process_report/settings.py
+++ b/process_report/settings.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
 from pydantic_settings import BaseSettings
+from pydantic import model_validator, ValidationError
 
 
 class Settings(BaseSettings):
@@ -17,6 +18,8 @@ class Settings(BaseSettings):
     )
     fetch_from_s3: bool = True
     upload_to_s3: bool = False
+
+    chrome_bin_path: str = "/usr/bin/chromium"
 
     # S3 Files
     pi_remote_filepath: str = "PIs/PI.csv"
@@ -36,5 +39,25 @@ class Settings(BaseSettings):
     bu_subsidy_amount: Decimal | None = None
     lenovo_charge_info: dict[str, Decimal] | None = None
 
+    @model_validator(mode="after")
+    def check_keycloak_auth(self):
+        if not self.coldfront_api_filepath and not (
+            self.keycloak_client_id and self.keycloak_client_secret
+        ):
+            raise ValueError(
+                "You must either set coldfront_api_filepath or provide keycloak credentials in "
+                "KEYCLOAK_CLIENT_ID and KEYCLOAK_CLIENT_SECRET"
+            )
 
-invoice_settings = Settings()
+        return self
+
+
+try:
+    invoice_settings = Settings()
+except ValidationError as e:
+    for error in e.errors():
+        if error["type"] == "missing":
+            print(f"Missing required environment variable: {error['loc'][0]}")
+        else:
+            print(f"Error in environment variable {error['loc']}: {error['msg']}")
+    raise

--- a/process_report/tests/integration/pytest.toml
+++ b/process_report/tests/integration/pytest.toml
@@ -1,0 +1,2 @@
+[pytest_env]
+COLDFRONT_API_FILEPATH = "/foo/coldfront_api.json"

--- a/process_report/tests/unit/invoices/test_pi_specific_invoice.py
+++ b/process_report/tests/unit/invoices/test_pi_specific_invoice.py
@@ -3,7 +3,6 @@ from unittest import TestCase, mock
 import pandas
 
 from process_report.tests import util as test_utils
-from process_report.invoices.pi_specific_invoice import CHROME_BIN_PATH
 
 
 class TestPISpecificInvoice(TestCase):
@@ -155,7 +154,7 @@ class TestPISpecificInvoice(TestCase):
             for i, pi_pdf_path in enumerate([pi_pdf_1, pi_pdf_2]):
                 chrome_arglist, _ = mock_subprocess_run.call_args_list[i]
                 answer_arglist = [
-                    CHROME_BIN_PATH,
+                    "/usr/bin/chromium",  # Default config value in settings.py
                     "--headless",
                     "--no-sandbox",
                     f"--print-to-pdf={pi_pdf_path}",

--- a/process_report/tests/unit/pytest.toml
+++ b/process_report/tests/unit/pytest.toml
@@ -1,0 +1,2 @@
+[pytest_env]
+COLDFRONT_API_FILEPATH = "/foo/coldfront_api.json"

--- a/process_report/tests/unit/test_util.py
+++ b/process_report/tests/unit/test_util.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, mock
+from unittest import TestCase
 import tempfile
 import pandas
 import os
@@ -138,20 +138,3 @@ class TestTimedProjects(TestCase):
         )
 
         assert nonbillable_projects.equals(expected_projects)
-
-
-class TestValidateRequiredEnvVars(TestCase):
-    @mock.patch.dict(
-        "os.environ", {"KEYCLOAK_CLIENT_ID": "test", "KEYCLOAK_CLIENT_SECRET": "test"}
-    )
-    def test_env_vars_valid(self):
-        process_report.validate_required_env_vars(
-            ["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
-        )
-
-    @mock.patch.dict("os.environ", {"KEYCLOAK_CLIENT_ID": "test"})
-    def test_env_vars_missing(self):
-        with pytest.raises(SystemExit):
-            process_report.validate_required_env_vars(
-                ["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
-            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Jinja2
 validators
 python-dateutil
 pydantic-settings
+pytest-env


### PR DESCRIPTION
Closes #168. Adhere to testing best practices as outlined in https://github.com/CCI-MOC/invoicing/pull/159#discussion_r2029179898 and https://github.com/CCI-MOC/invoicing/issues/168#issue-2974987046. Modify utils.py to accommodate changes. 

Edit (04/07/2026): We decided to move on configuration loading to the new `settings.py` module.