### PR TITLE
Suppress pandas FutureWarning from discount.py during PI PDF export

### DIFF
--- a/process_report/processors/discount_processor.py
+++ b/process_report/processors/discount_processor.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pandas
 
 from process_report.processors import processor
@@ -67,6 +69,10 @@ class DiscountProcessor(processor.Processor):
                     )
 
         remaining_discount_amount = discount_amount
+        invoice[pi_balance_field] = invoice[pi_balance_field].apply(
+            lambda x: Decimal(str(x))
+        )
+        invoice[balance_field] = invoice[balance_field].apply(lambda x: Decimal(str(x)))
         for i, row in pi_projects.iterrows():
             if remaining_discount_amount == 0:
                 break


### PR DESCRIPTION
Closes #184. Pandas emits a FutureWarning from discount.py when modifying invoice columns during PI PDF generation. This fixes the underlying issue, and warnings no longer appear during tests. 

Mentioned  here: https://github.com/CCI-MOC/invoicing/issues/180