### PR TITLE
Add integration test for headless Chrome PDF generation. 

### DIFF
--- a/.github/workflows/chromium-validation.yaml
+++ b/.github/workflows/chromium-validation.yaml
@@ -1,0 +1,34 @@
+name: Validate Chrome Integration
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-validation:
+    name: Run Integration Tests with Latest Chrome
+    runs-on: ubuntu-latest
+    env:
+      CHROME_BIN_PATH: /usr/bin/chromium
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Download and install latest Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium
+
+      - name: Run PDF generation integration test
+        run: |
+          python -m unittest process_report.tests.unit.test_chromium

--- a/process_report/tests/unit/test_chromium.py
+++ b/process_report/tests/unit/test_chromium.py
@@ -1,0 +1,59 @@
+import os
+
+import pandas as pd
+
+from process_report.invoices.pi_specific_invoice import PIInvoice
+from process_report.invoices import invoice
+from process_report.tests.base import BaseTestCaseWithTempDir
+
+
+class TestPIInvoiceExport(BaseTestCaseWithTempDir):
+    def setUp(self):
+        super().setUp()
+        self.invoice_month = "2024-01"
+
+        self.df = pd.DataFrame(
+            [
+                {
+                    invoice.INVOICE_DATE_FIELD: "2024-01-01",
+                    invoice.PROJECT_FIELD: "ProjectX",
+                    invoice.PROJECT_ID_FIELD: "PA-001",
+                    invoice.PI_FIELD: "Jane Doe",
+                    invoice.INVOICE_EMAIL_FIELD: "jane.doe@university.edu",
+                    invoice.INVOICE_ADDRESS_FIELD: "123 Campus Dr, Cityville",
+                    invoice.INSTITUTION_FIELD: "Test University",
+                    invoice.INSTITUTION_ID_FIELD: "TU-001",
+                    invoice.SU_HOURS_FIELD: 50,
+                    invoice.SU_TYPE_FIELD: "GBhr",
+                    invoice.RATE_FIELD: 2.0,
+                    invoice.GROUP_NAME_FIELD: "PrepaidGroupX",
+                    invoice.GROUP_INSTITUTION_FIELD: "Test University",
+                    invoice.GROUP_BALANCE_FIELD: 1000,
+                    invoice.COST_FIELD: 100,
+                    invoice.GROUP_BALANCE_USED_FIELD: 200,
+                    invoice.CREDIT_FIELD: 20,
+                    invoice.CREDIT_CODE_FIELD: "CRED123",
+                    invoice.BALANCE_FIELD: 80,
+                    invoice.IS_BILLABLE_FIELD: True,
+                    invoice.MISSING_PI_FIELD: False,
+                }
+            ]
+        )
+
+    def test_pi_invoice_pdf_generation(self):
+        pi_invoice = PIInvoice(
+            name=self.tempdir, invoice_month=self.invoice_month, data=self.df
+        )
+        pi_invoice.process()
+        pi_invoice.export()
+
+        output_pdfs = os.listdir(self.tempdir)
+
+        self.assertEqual(["Test University_Jane Doe_2024-01.pdf"], output_pdfs)
+
+        # Validate the PDF header
+        for pdf in output_pdfs:
+            pdf_path = os.path.join(self.tempdir, pdf)
+            with open(pdf_path, "rb") as f:
+                header = f.read(4)
+            self.assertEqual(header, b"%PDF")


### PR DESCRIPTION
Closes #145. Adds integration test to verify that PDF generation via headless Chrome works as expected. This ensures continued compatibility as Chromium evolves.

Brought up in: https://github.com/CCI-MOC/invoicing/issues/145#issue-2796145953