### PR TITLE
Added CLI option to pass in Coldfront API data

### DIFF
--- a/process_report/tests/unit/test_util.py
+++ b/process_report/tests/unit/test_util.py
@@ -111,9 +111,13 @@ class TestValidateRequiredEnvVars(TestCase):
         "os.environ", {"KEYCLOAK_CLIENT_ID": "test", "KEYCLOAK_CLIENT_SECRET": "test"}
     )
     def test_env_vars_valid(self):
-        process_report.validate_required_env_vars()
+        process_report.validate_required_env_vars(
+            ["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
+        )
 
     @mock.patch.dict("os.environ", {"KEYCLOAK_CLIENT_ID": "test"})
     def test_env_vars_missing(self):
         with self.assertRaises(SystemExit):
-            process_report.validate_required_env_vars()
+            process_report.validate_required_env_vars(
+                ["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
+            )

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -87,13 +87,14 @@ def new_coldfront_fetch_processor(
     invoice_month="0000-00",
     data=None,
     nonbillable_projects=None,
+    coldfront_data_filepath=None,
 ):
     if data is None:
         data = pandas.DataFrame()
     if nonbillable_projects is None:
         nonbillable_projects = []
     return coldfront_fetch_processor.ColdfrontFetchProcessor(
-        name, invoice_month, data, nonbillable_projects
+        name, invoice_month, data, nonbillable_projects, coldfront_data_filepath
     )
 
 


### PR DESCRIPTION
Closes #194. The filepath to a JSON file can be now passed through the CLI. This will allow injection of custom Coldfront data for ease of testing purposes.