### PR TITLE
Added nonbillable cluster list to billable processor

### DIFF
--- a/process_report/invoices/invoice.py
+++ b/process_report/invoices/invoice.py
@@ -55,6 +55,7 @@ MISSING_PI_FIELD = "Missing PI"
 PI_BALANCE_FIELD = "PI Balance"
 PROJECT_NAME_FIELD = "Project"
 GROUP_MANAGED_FIELD = "MGHPCC Managed"
+CLUSTER_NAME_FIELD = "Cluster Name"
 ###
 
 


### PR DESCRIPTION
Closes #165. More details in the commit message. This is blocking #167 and #152.

I have a feeling this solution for the `ocp-test` debacle is a bit clunky. Let me know what you guys think.