### PR TITLE
Refactor type handling in invoices

### DIFF
--- a/process_report/invoices/invoice.py
+++ b/process_report/invoices/invoice.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import pandas
+import pyarrow
 
 import process_report.util as util
 
@@ -58,6 +59,12 @@ GROUP_MANAGED_FIELD = "MGHPCC Managed"
 CLUSTER_NAME_FIELD = "Cluster Name"
 ###
 
+### Invoice column types
+BALANCE_FIELD_TYPE = pandas.ArrowDtype(pyarrow.decimal128(21, 2))
+STRING_FIELD_TYPE = pandas.StringDtype()
+BOOL_FIELD_TYPE = pandas.BooleanDtype()
+###
+
 
 @dataclass
 class Invoice:
@@ -109,6 +116,12 @@ class Invoice:
         Implement in subclass if necessary. May add or remove columns or rows
         that should or should not be exported after processing."""
         pass
+
+    def _create_column(self, column_name, column_type, value):
+        """Creates a new column in `self.data` with type and value."""
+        self.data[column_name] = pandas.Series(
+            [value] * len(self.data), dtype=column_type
+        )
 
     def _filter_columns(self):
         """Filters and renames columns before exporting"""

--- a/process_report/invoices/pi_specific_invoice.py
+++ b/process_report/invoices/pi_specific_invoice.py
@@ -105,6 +105,9 @@ class PIInvoice(invoice.Invoice):
                     lambda data: data if pandas.isna(data) else f"${data}"
                 )
 
+        pi_projects = pi_projects.astype(
+            invoice.STRING_FIELD_TYPE
+        )  # Prevents TypeError with Pandas dtypes
         pi_projects.fillna("", inplace=True)
 
         return pi_projects

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -6,11 +6,11 @@ from decimal import Decimal
 import os
 
 import pandas
-import pyarrow
 from nerc_rates import load_from_url
 
 from process_report import util
 from process_report.invoices import (
+    invoice,
     lenovo_invoice,
     nonbillable_invoice,
     billable_invoice,
@@ -438,8 +438,8 @@ def merge_csv(files):
         dataframe = pandas.read_csv(
             file,
             dtype={
-                COST_FIELD: pandas.ArrowDtype(pyarrow.decimal128(12, 2)),
-                RATE_FIELD: str,
+                COST_FIELD: invoice.BALANCE_FIELD_TYPE,
+                RATE_FIELD: invoice.STRING_FIELD_TYPE,
             },
         )
         dataframes.append(dataframe)

--- a/process_report/processors/bu_subsidy_processor.py
+++ b/process_report/processors/bu_subsidy_processor.py
@@ -19,7 +19,16 @@ class BUSubsidyProcessor(discount_processor.DiscountProcessor):
             else:
                 return project_alloc[: project_alloc.rfind("-")]
 
-        self.data[invoice.PROJECT_NAME_FIELD] = self.data.apply(get_project, axis=1)
+        self._create_column(
+            invoice.PROJECT_NAME_FIELD,
+            invoice.STRING_FIELD_TYPE,
+            self.data.apply(get_project, axis=1),
+        )
+        self._create_column(
+            invoice.SUBSIDY_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            0,
+        )
         self.data[invoice.SUBSIDY_FIELD] = Decimal(0)
 
     def _process(self):

--- a/process_report/processors/lenovo_processor.py
+++ b/process_report/processors/lenovo_processor.py
@@ -10,7 +10,13 @@ class LenovoProcessor(processor.Processor):
     SU_CHARGE_MULTIPLIER = 1
 
     def _process(self):
-        self.data[invoice.SU_CHARGE_FIELD] = self.SU_CHARGE_MULTIPLIER
-        self.data[invoice.LENOVO_CHARGE_FIELD] = (
-            self.data[invoice.SU_HOURS_FIELD] * self.data[invoice.SU_CHARGE_FIELD]
+        self._create_column(
+            invoice.SU_CHARGE_FIELD,
+            int,
+            self.SU_CHARGE_MULTIPLIER,
+        )
+        self._create_column(
+            invoice.LENOVO_CHARGE_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            self.data[invoice.SU_HOURS_FIELD] * self.data[invoice.SU_CHARGE_FIELD],
         )

--- a/process_report/processors/new_pi_credit_processor.py
+++ b/process_report/processors/new_pi_credit_processor.py
@@ -183,10 +183,26 @@ class NewPICreditProcessor(discount_processor.DiscountProcessor):
         return (data, old_pi_df)
 
     def _prepare(self):
-        self.data[invoice.CREDIT_FIELD] = None
-        self.data[invoice.CREDIT_CODE_FIELD] = None
-        self.data[invoice.PI_BALANCE_FIELD] = self.data[invoice.COST_FIELD]
-        self.data[invoice.BALANCE_FIELD] = self.data[invoice.COST_FIELD]
+        self._create_column(
+            invoice.CREDIT_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.CREDIT_CODE_FIELD,
+            invoice.STRING_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.PI_BALANCE_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            self.data[invoice.COST_FIELD],
+        )
+        self._create_column(
+            invoice.BALANCE_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            self.data[invoice.COST_FIELD],
+        )
         self.old_pi_df = self._load_old_pis(self.old_pi_filepath)
 
     def _process(self):

--- a/process_report/processors/prepayment_processor.py
+++ b/process_report/processors/prepayment_processor.py
@@ -38,11 +38,31 @@ class PrepaymentProcessor(discount_processor.DiscountProcessor):
         return prepay_debits
 
     def _prepare(self):
-        self.data[invoice.GROUP_NAME_FIELD] = None
-        self.data[invoice.GROUP_INSTITUTION_FIELD] = None
-        self.data[invoice.GROUP_MANAGED_FIELD] = None
-        self.data[invoice.GROUP_BALANCE_FIELD] = None
-        self.data[invoice.GROUP_BALANCE_USED_FIELD] = None
+        self._create_column(
+            invoice.GROUP_NAME_FIELD,
+            invoice.STRING_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.GROUP_INSTITUTION_FIELD,
+            invoice.STRING_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.GROUP_MANAGED_FIELD,
+            invoice.BOOL_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.GROUP_BALANCE_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            None,
+        )
+        self._create_column(
+            invoice.GROUP_BALANCE_USED_FIELD,
+            invoice.BALANCE_FIELD_TYPE,
+            None,
+        )
 
         self.prepay_debits = self._load_prepay_debits(self.prepay_debits_filepath)
         self.group_info_dict = self._get_prepay_group_dict()

--- a/process_report/processors/validate_billable_pi_processor.py
+++ b/process_report/processors/validate_billable_pi_processor.py
@@ -56,7 +56,15 @@ class ValidateBillablePIsProcessor(processor.Processor):
         )
 
     def _process(self):
-        self.data[invoice.IS_BILLABLE_FIELD] = self._get_billables(
-            self.data, self.nonbillable_pis, self.nonbillable_projects
+        self._create_column(
+            invoice.IS_BILLABLE_FIELD,
+            invoice.BOOL_FIELD_TYPE,
+            self._get_billables(
+                self.data, self.nonbillable_pis, self.nonbillable_projects
+            ),
         )
-        self.data[invoice.MISSING_PI_FIELD] = self._validate_pi_names(self.data)
+        self._create_column(
+            invoice.MISSING_PI_FIELD,
+            invoice.BOOL_FIELD_TYPE,
+            self._validate_pi_names(self.data),
+        )

--- a/process_report/tests/base.py
+++ b/process_report/tests/base.py
@@ -3,8 +3,48 @@ import shutil
 from pathlib import Path
 from unittest import TestCase
 
+import pandas
+import pyarrow
 
-class BaseTestCaseWithTempDir(TestCase):
+
+### Invoice column types
+BOOL_FIELD_TYPE = pandas.BooleanDtype()
+STRING_FIELD_TYPE = pandas.StringDtype()
+BALANCE_FIELD_TYPE = pandas.ArrowDtype(pyarrow.decimal128(21, 2))
+###
+
+
+class BaseTestCase(TestCase):
+    field_type_mapping = {
+        "Is Billable": BOOL_FIELD_TYPE,
+        "Missing PI": BOOL_FIELD_TYPE,
+        "Rate": STRING_FIELD_TYPE,
+        "Cost": BALANCE_FIELD_TYPE,
+        "Credit": BALANCE_FIELD_TYPE,
+        "Subsidy": BALANCE_FIELD_TYPE,
+        "Balance": BALANCE_FIELD_TYPE,
+        "Prepaid Group Managed": BOOL_FIELD_TYPE,
+        "Prepaid Group Balance": BALANCE_FIELD_TYPE,
+        "Prepaid Group Used": BALANCE_FIELD_TYPE,
+    }
+
+    def _create_test_invoice(self, data: dict) -> pandas.DataFrame:
+        """
+        Given a dictionary of data, create a DataFrame that represents an invoice.
+        Also standardizes the type for some columns mostly those that expect monetary
+        values, like BALANCE_FIELD, COST_FIELD, etc. These columns are usually
+        converted to pyarrow.decimal128(21, 2)
+        """
+        standard_dtypes = {}
+        for column_name in data.keys():
+            if column_name in self.field_type_mapping:
+                standard_dtypes[column_name] = self.field_type_mapping[column_name]
+
+        test_invoice = pandas.DataFrame(data)
+        return test_invoice.astype(standard_dtypes)
+
+
+class BaseTestCaseWithTempDir(BaseTestCase):
     def setUp(self):
         self.tempdir = Path(tempfile.TemporaryDirectory(delete=False).name)
 

--- a/process_report/tests/unit/invoices/test_base_invoice.py
+++ b/process_report/tests/unit/invoices/test_base_invoice.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
 import pandas
 
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestBaseInvoice(TestCase):
+class TestBaseInvoice(base.BaseTestCase):
     def test_filter_exported_columns(self):
         test_invoice = pandas.DataFrame(columns=["C1", "C2", "C3", "C4", "C5"])
         answer_invoice = pandas.DataFrame(columns=["C1", "C3R", "C5R"])
@@ -16,6 +16,20 @@ class TestBaseInvoice(TestCase):
         result_invoice = inv.export_data
 
         self.assertTrue(result_invoice.equals(answer_invoice))
+
+    def test_create_column(self):
+        test_invoice = self._create_test_invoice({"Col1": [1, 2], "Col2": [3, 4]})
+        answer_invoice = test_invoice.copy()
+        answer_invoice["Col3"] = "default"
+        answer_invoice["Col4"] = 10.0
+        answer_invoice["Col3"] = answer_invoice["Col3"].astype(base.STRING_FIELD_TYPE)
+        answer_invoice["Col4"] = answer_invoice["Col4"].astype(base.BALANCE_FIELD_TYPE)
+
+        inv = test_utils.new_base_invoice(data=test_invoice)
+        inv._create_column("Col3", base.STRING_FIELD_TYPE, "default")
+        inv._create_column("Col4", base.BALANCE_FIELD_TYPE, 10.0)
+
+        self.assertTrue(inv.data.equals(answer_invoice))
 
 
 class TestUploadToS3(TestCase):

--- a/process_report/tests/unit/invoices/test_nerc_total_invoice.py
+++ b/process_report/tests/unit/invoices/test_nerc_total_invoice.py
@@ -1,28 +1,18 @@
-from unittest import TestCase, mock
-import pandas
+from unittest import mock
 
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 from process_report.institute_list_models import InstituteList
 
 
-class TestNERCTotalInvoice(TestCase):
+class TestNERCTotalInvoice(base.BaseTestCase):
     def _get_test_invoice(
         self,
         institutions,
-        is_billable=None,
-        missing_pi=None,
-        group_managed=None,
+        is_billable=True,
+        missing_pi=False,
+        group_managed=True,
     ):
-        if not is_billable:
-            is_billable = [True for _ in range(len(institutions))]
-
-        if not missing_pi:
-            missing_pi = [False for _ in range(len(institutions))]
-
-        if not group_managed:
-            group_managed = [True for _ in range(len(institutions))]
-
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Institution": institutions,
                 "Is Billable": is_billable,

--- a/process_report/tests/unit/invoices/test_pi_specific_invoice.py
+++ b/process_report/tests/unit/invoices/test_pi_specific_invoice.py
@@ -1,39 +1,30 @@
 import tempfile
-from unittest import TestCase, mock
+from unittest import mock
 import pandas
 
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestPISpecificInvoice(TestCase):
+class TestPISpecificInvoice(base.BaseTestCase):
     def _get_test_invoice(
         self,
         pi,
         institution,
         balance,
-        is_billable=None,
-        missing_pi=None,
+        is_billable=True,
+        missing_pi=False,
         group_name=None,
     ):
-        if not is_billable:
-            is_billable = [True] * len(pi)
-
-        if not missing_pi:
-            missing_pi = [False] * len(pi)
-
-        if not group_name:
-            group_name = [None] * len(pi)
-
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Manager (PI)": pi,
                 "Institution": institution,
                 "Is Billable": is_billable,
                 "Missing PI": missing_pi,
                 "Prepaid Group Name": group_name,
-                "Prepaid Group Institution": ["" for _ in range(len(pi))],
-                "Prepaid Group Balance": [0 for _ in range(len(pi))],
-                "Prepaid Group Used": [0 for _ in range(len(pi))],
+                "Prepaid Group Institution": "",
+                "Prepaid Group Balance": 0,
+                "Prepaid Group Used": 0,
                 "Balance": balance,
             }
         )
@@ -73,6 +64,7 @@ class TestPISpecificInvoice(TestCase):
             answer_invoice_pi1[column_name] = answer_invoice_pi1[column_name].apply(
                 add_dollar_sign
             )
+        answer_invoice_pi1 = answer_invoice_pi1.astype(base.STRING_FIELD_TYPE)
         answer_invoice_pi1.fillna("", inplace=True)
 
         answer_invoice_pi2 = (
@@ -96,6 +88,8 @@ class TestPISpecificInvoice(TestCase):
         answer_invoice_pi2["Balance"] = answer_invoice_pi2["Balance"].apply(
             add_dollar_sign
         )
+
+        answer_invoice_pi2 = answer_invoice_pi2.astype(base.STRING_FIELD_TYPE)
         answer_invoice_pi2.fillna("", inplace=True)
 
         pi_inv = test_utils.new_pi_specific_invoice(data=test_invoice)

--- a/process_report/tests/unit/processors/test_bu_subsidy_processor.py
+++ b/process_report/tests/unit/processors/test_bu_subsidy_processor.py
@@ -1,10 +1,7 @@
-from unittest import TestCase
-import pandas
-
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestBUSubsidyProcessor(TestCase):
+class TestBUSubsidyProcessor(base.BaseTestCase):
     def _assert_result_invoice(
         self,
         subsidy_amount,
@@ -28,27 +25,15 @@ class TestBUSubsidyProcessor(TestCase):
         pi,
         pi_balances,
         balances=None,
-        project_names=None,
-        institution=None,
-        is_billable=None,
-        missing_pi=None,
+        project_names="Project",
+        institution="Boston University",
+        is_billable=True,
+        missing_pi=False,
     ):
         if not balances:
             balances = pi_balances
 
-        if not project_names:
-            project_names = ["Project" for _ in range(len(pi))]
-
-        if not institution:
-            institution = ["Boston University" for _ in range(len(pi))]
-
-        if not is_billable:
-            is_billable = [True for _ in range(len(pi))]
-
-        if not missing_pi:
-            missing_pi = [False for _ in range(len(pi))]
-
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Manager (PI)": pi,
                 "Project - Allocation": project_names,

--- a/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
+++ b/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
@@ -1,31 +1,18 @@
-from unittest import TestCase, mock
-import pandas
+from unittest import mock
 
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestColdfrontFetchProcessor(TestCase):
+class TestColdfrontFetchProcessor(base.BaseTestCase):
     def _get_test_invoice(
         self,
         allocation_project_id,
-        allocation_project_name=None,
-        pi=None,
-        institute_code=None,
-        cluster_name=None,
+        allocation_project_name="",
+        pi="",
+        institute_code="",
+        cluster_name="",
     ):
-        if not pi:
-            pi = [""] * len(allocation_project_id)
-
-        if not institute_code:
-            institute_code = [""] * len(allocation_project_id)
-
-        if not allocation_project_name:
-            allocation_project_name = [""] * len(allocation_project_id)
-
-        if not cluster_name:
-            cluster_name = [""] * len(allocation_project_id)
-
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Manager (PI)": pi,
                 "Project - Allocation": allocation_project_name,

--- a/process_report/tests/unit/processors/test_lenovo_processor.py
+++ b/process_report/tests/unit/processors/test_lenovo_processor.py
@@ -1,12 +1,9 @@
-from unittest import TestCase
-import pandas
-
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestLenovoProcessor(TestCase):
+class TestLenovoProcessor(base.BaseTestCase):
     def test_process_lenovo(self):
-        test_invoice = pandas.DataFrame(
+        test_invoice = self._create_test_invoice(
             {
                 "SU Hours (GBhr or SUhr)": [1, 10, 100, 4, 432, 10],
             }
@@ -19,4 +16,7 @@ class TestLenovoProcessor(TestCase):
 
         lenovo_proc = test_utils.new_lenovo_processor(data=test_invoice)
         lenovo_proc.process()
-        self.assertTrue(lenovo_proc.data.equals(answer_invoice))
+        output_invoice = lenovo_proc.data
+
+        answer_invoice = answer_invoice.astype(output_invoice.dtypes)
+        self.assertTrue(output_invoice.equals(answer_invoice))

--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -84,18 +84,9 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         self.assertTrue(output_old_pi_df.equals(answer_old_pi_df))
 
     def _get_test_invoice(
-        self, pi, cost, su_type=None, is_billable=None, missing_pi=None
+        self, pi, cost, su_type="CPU", is_billable=True, missing_pi=False
     ):
-        if not su_type:
-            su_type = ["CPU" for _ in range(len(pi))]
-
-        if not is_billable:
-            is_billable = [True for _ in range(len(pi))]
-
-        if not missing_pi:
-            missing_pi = [False for _ in range(len(pi))]
-
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Manager (PI)": pi,
                 "Cost": cost,

--- a/process_report/tests/unit/processors/test_prepayment_processor.py
+++ b/process_report/tests/unit/processors/test_prepayment_processor.py
@@ -43,12 +43,12 @@ class TestPrepaymentProcessor(BaseTestCaseWithTempDir):
         if not balances:
             balances = pi_balances
 
-        return pandas.DataFrame(
+        return self._create_test_invoice(
             {
                 "Project": project_names,
                 "PI Balance": pi_balances,
                 "Balance": balances,
-                "Invoice Email": [None] * len(project_names),
+                "Invoice Email": None,
             }
         )
 

--- a/process_report/tests/unit/processors/test_validate_alias_processor.py
+++ b/process_report/tests/unit/processors/test_validate_alias_processor.py
@@ -1,18 +1,15 @@
-from unittest import TestCase
-import pandas
-
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestValidateAliasProcessor(TestCase):
+class TestValidateAliasProcessor(base.BaseTestCase):
     def test_validate_alias(self):
         alias_map = {"PI1": ["PI1_1", "PI1_2"], "PI2": ["PI2_1"]}
-        test_data = pandas.DataFrame(
+        test_data = self._create_test_invoice(
             {
                 "Manager (PI)": ["PI1", "PI1_1", "PI1_2", "PI2_1", "PI2_1"],
             }
         )
-        answer_data = pandas.DataFrame(
+        answer_data = self._create_test_invoice(
             {
                 "Manager (PI)": ["PI1", "PI1", "PI1", "PI2", "PI2"],
             }

--- a/process_report/tests/unit/processors/test_validate_billable_pi_processor.py
+++ b/process_report/tests/unit/processors/test_validate_billable_pi_processor.py
@@ -1,12 +1,11 @@
-from unittest import TestCase
 import pandas
 import uuid
 import math
 
-from process_report.tests import util as test_utils
+from process_report.tests import base, util as test_utils
 
 
-class TestValidateBillablePIProcessor(TestCase):
+class TestValidateBillablePIProcessor(base.BaseTestCase):
     def test_remove_nonbillables(self):
         pis = [uuid.uuid4().hex for x in range(10)]
         projects = [uuid.uuid4().hex for x in range(10)]
@@ -18,7 +17,7 @@ class TestValidateBillablePIProcessor(TestCase):
         ]  # Test for case-insentivity
         billable_pis = pis[3:6]
 
-        data = pandas.DataFrame(
+        data = self._create_test_invoice(
             {
                 "Manager (PI)": pis,
                 "Project - Allocation": projects,
@@ -42,7 +41,7 @@ class TestValidateBillablePIProcessor(TestCase):
         self.assertTrue(data["Manager (PI)"].tolist() == billable_pis)
 
     def test_empty_pi_name(self):
-        test_data = pandas.DataFrame(
+        test_data = self._create_test_invoice(
             {
                 "Manager (PI)": ["PI1", math.nan, "PI1", "PI2", "PI2"],
                 "Project - Allocation": [


### PR DESCRIPTION
Closes #191. More details in the commit message.

Currently, the test cases are failing because the PI-specific invoice [injects an incompatible value in the invoice dataframe](https://github.com/CCI-MOC/invoicing/blob/54019b2f237e00f8e623aff3ea98a065102920ed/process_report/invoices/pi_specific_invoice.py#L108). After some thinking, I thought the PI invoice could do some refactoring in that spot as well. I'll put this as a draft for now while I work on refactor the PI invoice.