### PR TITLE
Implemented ocp-test invoice

### DIFF
--- a/process_report/invoices/ocp_test_invoice.py
+++ b/process_report/invoices/ocp_test_invoice.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+import process_report.invoices.invoice as invoice
+
+
+@dataclass
+class OcpTestInvoice(invoice.Invoice):
+    export_columns_list = [
+        invoice.INVOICE_DATE_FIELD,
+        invoice.PROJECT_FIELD,
+        invoice.PROJECT_ID_FIELD,
+        invoice.PI_FIELD,
+        invoice.INVOICE_EMAIL_FIELD,
+        invoice.INVOICE_ADDRESS_FIELD,
+        invoice.INSTITUTION_FIELD,
+        invoice.INSTITUTION_ID_FIELD,
+        invoice.SU_HOURS_FIELD,
+        invoice.SU_TYPE_FIELD,
+        invoice.RATE_FIELD,
+        invoice.COST_FIELD,
+    ]
+
+    def _prepare_export(self):
+        self.export_data = self.data[
+            self.data[invoice.CLUSTER_NAME_FIELD] == "ocp-test"
+        ]

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -19,6 +19,7 @@ from process_report.invoices import (
     pi_specific_invoice,
     MOCA_prepaid_invoice,
     prepay_credits_snapshot,
+    ocp_test_invoice,
 )
 from process_report.processors import (
     coldfront_fetch_processor,
@@ -199,6 +200,12 @@ def main():
         "--Lenovo-file",
         required=False,
         default="Lenovo",
+        help="Name of output csv for Lenovo SU Types invoice",
+    )
+    parser.add_argument(
+        "--ocp-test-file",
+        required=False,
+        default="OCP-TEST",
         help="Name of output csv for Lenovo SU Types invoice",
     )
     parser.add_argument(
@@ -384,6 +391,10 @@ def main():
         prepay_contacts=prepay_info,
     )
 
+    ocp_test_inv = ocp_test_invoice.OcpTestInvoice(
+        name="", invoice_month=invoice_month, data=processed_data.copy()
+    )
+
     util.process_and_export_invoices(
         [
             lenovo_inv,
@@ -394,6 +405,7 @@ def main():
             pi_inv,
             moca_prepaid_inv,
             prepay_credits_snap,
+            ocp_test_inv,
         ],
         args.upload_to_s3,
     )


### PR DESCRIPTION
Closes #167. Projects belonging to the `ocp-test` cluster will be added to a new ocp-test invoice

@joachimweyl The default name for the invoice is `OCP-TEST YYYY-MM.csv`. Let me know if this is fine. If not, I can create a custom name for it (it would just require adding a bit more code)