### PR TITLE
Fixed ocp test invoice not given a name

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -205,7 +205,7 @@ def main():
     parser.add_argument(
         "--ocp-test-file",
         required=False,
-        default="OCP-TEST",
+        default="OCP_TEST",
         help="Name of output csv for Openshift test cluster invoice",
     )
     parser.add_argument(
@@ -392,7 +392,7 @@ def main():
     )
 
     ocp_test_inv = ocp_test_invoice.OcpTestInvoice(
-        name="", invoice_month=invoice_month, data=processed_data.copy()
+        name=args.ocp_test_file, invoice_month=invoice_month, data=processed_data.copy()
     )
 
     util.process_and_export_invoices(


### PR DESCRIPTION
The cli argument for the invoice was never passed, so it just had a blank name like `<YYYY-MM>.csv`.