### PR TITLE
Chromium test is not a unit test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,12 +1,12 @@
-name: Validate Chrome Integration
+name: Integration tests
 
 on:
   push:
   pull_request:
 
 jobs:
-  run-validation:
-    name: Run Integration Tests with Latest Chrome
+  run-integration-tests:
+    name: Run Integration Tests
     runs-on: ubuntu-latest
     env:
       CHROME_BIN_PATH: /usr/bin/chromium
@@ -24,11 +24,11 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: Download and install latest Chrome
+      - name: Download and install latest Chromium
         run: |
           sudo apt-get update
           sudo apt-get install -y chromium
 
-      - name: Run PDF generation integration test
+      - name: Run integration tests
         run: |
-          python -m unittest process_report.tests.unit.test_chromium
+          python -m unittest discover -s process_report/tests/integration

--- a/process_report/invoices/pi_specific_invoice.py
+++ b/process_report/invoices/pi_specific_invoice.py
@@ -13,6 +13,7 @@ import process_report.util as util
 
 
 TEMPLATE_DIR_PATH = "process_report/templates"
+CHROME_BIN_PATH = os.environ.get("CHROME_BIN_PATH", "/usr/bin/chromium")
 
 
 logger = logging.getLogger(__name__)
@@ -120,12 +121,9 @@ class PIInvoice(invoice.Invoice):
             temp_fd.flush()
 
         def _create_pdf_invoice(temp_fd_name):
-            chrome_binary_location = os.environ.get(
-                "CHROME_BIN_PATH", "/usr/bin/chromium"
-            )
-            if not os.path.exists(chrome_binary_location):
+            if not os.path.exists(CHROME_BIN_PATH):
                 sys.exit(
-                    f"Chrome binary does not exist at {chrome_binary_location}. Make sure the env var CHROME_BIN_PATH is set correctly and that Google Chrome is installed"
+                    f"Chrome binary does not exist at {CHROME_BIN_PATH}. Make sure the env var CHROME_BIN_PATH is set correctly and that Google Chrome is installed"
                 )
 
             invoice_pdf_path = (
@@ -133,7 +131,7 @@ class PIInvoice(invoice.Invoice):
             )
             subprocess.run(
                 [
-                    chrome_binary_location,
+                    CHROME_BIN_PATH,
                     "--headless",
                     "--no-sandbox",
                     f"--print-to-pdf={invoice_pdf_path}",

--- a/process_report/tests/integration/test_chromium.py
+++ b/process_report/tests/integration/test_chromium.py
@@ -1,4 +1,5 @@
 import os
+from typing import override
 
 import pandas as pd
 
@@ -8,6 +9,10 @@ from process_report.tests.base import BaseTestCaseWithTempDir
 
 
 class TestPIInvoiceExport(BaseTestCaseWithTempDir):
+    invoice_month: str = ""
+    df: pd.DataFrame = pd.DataFrame()
+
+    @override
     def setUp(self):
         super().setUp()
         self.invoice_month = "2024-01"
@@ -42,7 +47,7 @@ class TestPIInvoiceExport(BaseTestCaseWithTempDir):
 
     def test_pi_invoice_pdf_generation(self):
         pi_invoice = PIInvoice(
-            name=self.tempdir, invoice_month=self.invoice_month, data=self.df
+            name=str(self.tempdir), invoice_month=self.invoice_month, data=self.df
         )
         pi_invoice.process()
         pi_invoice.export()

--- a/process_report/tests/unit/invoices/test_pi_specific_invoice.py
+++ b/process_report/tests/unit/invoices/test_pi_specific_invoice.py
@@ -3,6 +3,7 @@ from unittest import TestCase, mock
 import pandas
 
 from process_report.tests import util as test_utils
+from process_report.invoices.pi_specific_invoice import CHROME_BIN_PATH
 
 
 class TestPISpecificInvoice(TestCase):
@@ -137,7 +138,7 @@ class TestPISpecificInvoice(TestCase):
             for i, pi_pdf_path in enumerate([pi_pdf_1, pi_pdf_2]):
                 chrome_arglist, _ = mock_subprocess_run.call_args_list[i]
                 answer_arglist = [
-                    "/usr/bin/chromium",
+                    CHROME_BIN_PATH,
                     "--headless",
                     "--no-sandbox",
                     f"--print-to-pdf={pi_pdf_path}",


### PR DESCRIPTION
Relocate tests/unit/test_chromium.py to tests/integration/test_chromium.py.

The chromium test is not a unit test -- it has an external dependency on
Chromium. By relocating it to tests/integration, we ensure that the unit
tests run without errors.

This commit also contains some minor changes to suppress warnings from
strict type checkers.