### PR TITLE
Replace unittest assert with pytest asserts

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r process_report/tests/test-requirements.txt
 
       - name: Download and install latest Chromium
         run: |
@@ -31,4 +32,4 @@ jobs:
 
       - name: Run integration tests
         run: |
-          python -m unittest discover -s process_report/tests/integration
+          python -m pytest process_report/tests/integration

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,7 +19,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r process_report/tests/test-requirements.txt
 
       - name: Run unit tests
         run: |
-          python -m unittest discover -s process_report/tests/unit
+          python -m pytest process_report/tests/unit

--- a/process_report/tests/integration/test_chromium.py
+++ b/process_report/tests/integration/test_chromium.py
@@ -54,11 +54,11 @@ class TestPIInvoiceExport(BaseTestCaseWithTempDir):
 
         output_pdfs = os.listdir(self.tempdir)
 
-        self.assertEqual(["Test University_Jane Doe_2024-01.pdf"], output_pdfs)
+        assert output_pdfs == ["Test University_Jane Doe_2024-01.pdf"]
 
         # Validate the PDF header
         for pdf in output_pdfs:
             pdf_path = os.path.join(self.tempdir, pdf)
             with open(pdf_path, "rb") as f:
                 header = f.read(4)
-            self.assertEqual(header, b"%PDF")
+            assert header == b"%PDF"

--- a/process_report/tests/unit/invoices/test_base_invoice.py
+++ b/process_report/tests/unit/invoices/test_base_invoice.py
@@ -15,7 +15,7 @@ class TestBaseInvoice(TestCase):
         inv._filter_columns()
         result_invoice = inv.export_data
 
-        self.assertTrue(result_invoice.equals(answer_invoice))
+        assert result_invoice.equals(answer_invoice)
 
 
 class TestUploadToS3(TestCase):
@@ -62,4 +62,4 @@ class TestUploadToS3(TestCase):
             sample_base_invoice.export_s3(mock_bucket)
 
         for i, call_args in enumerate(mock_bucket.upload_file.call_args_list):
-            self.assertTrue(answers[i] in call_args)
+            assert answers[i] in call_args

--- a/process_report/tests/unit/invoices/test_credits_snapshot.py
+++ b/process_report/tests/unit/invoices/test_credits_snapshot.py
@@ -38,4 +38,4 @@ class TestCreditsSnapshot(TestCase):
         )
         output_snapshot = new_prepayment_proc._get_prepay_credits_snapshot()
 
-        self.assertTrue(answer_credits_snapshot.equals(output_snapshot))
+        assert answer_credits_snapshot.equals(output_snapshot)

--- a/process_report/tests/unit/invoices/test_nerc_total_invoice.py
+++ b/process_report/tests/unit/invoices/test_nerc_total_invoice.py
@@ -66,4 +66,4 @@ class TestNERCTotalInvoice(TestCase):
         )
         test_inv._prepare_export()
         output_invoice = test_inv.export_data
-        self.assertTrue(output_invoice.equals(answer_invoice))
+        assert output_invoice.equals(answer_invoice)

--- a/process_report/tests/unit/invoices/test_pi_specific_invoice.py
+++ b/process_report/tests/unit/invoices/test_pi_specific_invoice.py
@@ -101,10 +101,10 @@ class TestPISpecificInvoice(TestCase):
 
         pi_inv = test_utils.new_pi_specific_invoice(data=test_invoice)
         output_invoice = pi_inv._get_pi_dataframe(test_invoice, "PI1")
-        self.assertTrue(answer_invoice_pi1.equals(output_invoice))
+        assert answer_invoice_pi1.equals(output_invoice)
 
         output_invoice = pi_inv._get_pi_dataframe(test_invoice, "PI2")
-        self.assertTrue(answer_invoice_pi2.equals(output_invoice))
+        assert answer_invoice_pi2.equals(output_invoice)
 
     @mock.patch("process_report.invoices.invoice.Invoice._filter_columns")
     @mock.patch("os.path.exists")
@@ -144,4 +144,4 @@ class TestPISpecificInvoice(TestCase):
                     f"--print-to-pdf={pi_pdf_path}",
                     "--no-pdf-header-footer",
                 ]
-                self.assertTrue(answer_arglist == chrome_arglist[0][:-1])
+                assert answer_arglist == chrome_arglist[0][:-1]

--- a/process_report/tests/unit/processors/test_add_institution_processor.py
+++ b/process_report/tests/unit/processors/test_add_institution_processor.py
@@ -33,6 +33,4 @@ class TestAddInstitute(TestCase):
         }
 
         for pi_email, answer in answers.items():
-            self.assertEqual(
-                util.get_institution_from_pi(institute_map, pi_email), answer
-            )
+            assert util.get_institution_from_pi(institute_map, pi_email) == answer

--- a/process_report/tests/unit/processors/test_bu_subsidy_processor.py
+++ b/process_report/tests/unit/processors/test_bu_subsidy_processor.py
@@ -21,7 +21,7 @@ class TestBUSubsidyProcessor(TestCase):
         output_invoice = new_bu_subsidy_proc.data
         answer_invoice = answer_invoice.astype(output_invoice.dtypes)
 
-        self.assertTrue(output_invoice.equals(answer_invoice))
+        assert output_invoice.equals(answer_invoice)
 
     def _get_test_invoice(
         self,

--- a/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
+++ b/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, mock
 import pandas
+import pytest
 
 from process_report.tests import util as test_utils
 
@@ -74,7 +75,7 @@ class TestColdfrontFetchProcessor(TestCase):
         )
         test_coldfront_fetch_proc.process()
         output_invoice = test_coldfront_fetch_proc.data
-        self.assertTrue(output_invoice.equals(answer_invoice))
+        assert output_invoice.equals(answer_invoice)
 
     @mock.patch(
         "process_report.processors.coldfront_fetch_processor.ColdfrontFetchProcessor._fetch_coldfront_allocation_api",
@@ -93,12 +94,11 @@ class TestColdfrontFetchProcessor(TestCase):
             data=test_invoice, nonbillable_projects=test_nonbillable_projects
         )
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             test_coldfront_fetch_proc.process()
 
-        self.assertEqual(
-            str(cm.exception),
-            f"Projects {answer_project_set} not found in Coldfront and are billable! Please check the project names",
+        assert str(cm.value) == (
+            f"Projects {answer_project_set} not found in Coldfront and are billable! Please check the project names"
         )
 
     @mock.patch(
@@ -128,4 +128,4 @@ class TestColdfrontFetchProcessor(TestCase):
         )
         test_coldfront_fetch_proc.process()
         output_invoice = test_coldfront_fetch_proc.data
-        self.assertTrue(output_invoice.equals(answer_invoice))
+        assert output_invoice.equals(answer_invoice)

--- a/process_report/tests/unit/processors/test_lenovo_processor.py
+++ b/process_report/tests/unit/processors/test_lenovo_processor.py
@@ -25,4 +25,4 @@ class TestLenovoProcessor(TestCase):
             data=test_invoice, su_charge_info=test_su_charge_info
         )
         lenovo_proc.process()
-        self.assertTrue(lenovo_proc.data.equals(answer_invoice))
+        assert lenovo_proc.data.equals(answer_invoice)

--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, mock
 import pandas
+import pytest
 
 from process_report.institute_list_models import InstituteList
 from process_report.tests import util as test_utils
@@ -40,19 +41,19 @@ class TestNERCRates(TestCase):
         # When no partnerships are active
         sample_proc.invoice_month = "2024-01"
         output_df = sample_proc._filter_partners(sample_df)
-        self.assertTrue(output_df.empty)
+        assert output_df.empty
 
         # When some partnerships are active
         sample_proc.invoice_month = "2024-06"
         output_df = sample_proc._filter_partners(sample_df)
         answer_df = pandas.DataFrame({"Institution": ["BU", "HU"]})
-        self.assertTrue(output_df.equals(answer_df))
+        assert output_df.equals(answer_df)
 
         # When all partnerships are active
         sample_proc.invoice_month = "2024-12"
         output_df = sample_proc._filter_partners(sample_df)
         answer_df = pandas.DataFrame({"Institution": ["BU", "HU", "NEU"]})
-        self.assertTrue(output_df.equals(answer_df))
+        assert output_df.equals(answer_df)
 
 
 class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
@@ -80,8 +81,8 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
             by="PI", ignore_index=True
         )
 
-        self.assertTrue(output_invoice.equals(answer_invoice))
-        self.assertTrue(output_old_pi_df.equals(answer_old_pi_df))
+        assert output_invoice.equals(answer_invoice)
+        assert output_old_pi_df.equals(answer_old_pi_df)
 
     def _get_test_invoice(
         self, pi, cost, su_type=None, is_billable=None, missing_pi=None
@@ -525,5 +526,5 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         )
         invoice_month = "2024-03"
         test_invoice = test_utils.new_new_pi_credit_processor()
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             test_invoice._get_pi_age(old_pi_df, "PI1", invoice_month)

--- a/process_report/tests/unit/processors/test_prepayment_processor.py
+++ b/process_report/tests/unit/processors/test_prepayment_processor.py
@@ -36,8 +36,8 @@ class TestPrepaymentProcessor(BaseTestCaseWithTempDir):
             output_prepay_debits.dtypes
         ).sort_values(by="Month", ignore_index=True)
 
-        self.assertTrue(output_invoice.equals(answer_invoice))
-        self.assertTrue(output_prepay_debits.equals(answer_prepay_debits))
+        assert output_invoice.equals(answer_invoice)
+        assert output_prepay_debits.equals(answer_prepay_debits)
 
     def _get_test_invoice(self, project_names, pi_balances, balances=None):
         if not balances:

--- a/process_report/tests/unit/processors/test_validate_alias_processor.py
+++ b/process_report/tests/unit/processors/test_validate_alias_processor.py
@@ -22,4 +22,4 @@ class TestValidateAliasProcessor(TestCase):
             data=test_data, alias_map=alias_map
         )
         validate_pi_alias_proc.process()
-        self.assertTrue(answer_data.equals(validate_pi_alias_proc.data))
+        assert answer_data.equals(validate_pi_alias_proc.data)

--- a/process_report/tests/unit/processors/test_validate_billable_pi_processor.py
+++ b/process_report/tests/unit/processors/test_validate_billable_pi_processor.py
@@ -34,12 +34,10 @@ class TestValidateBillablePIProcessor(TestCase):
         validate_billable_pi_proc.process()
         data = validate_billable_pi_proc.data
         data = data[data["Is Billable"]]
-        self.assertTrue(data[data["Manager (PI)"].isin(nonbillable_pis)].empty)
-        self.assertTrue(
-            data[data["Project - Allocation"].isin(nonbillable_projects)].empty
-        )
-        self.assertTrue(data[data["Cluster Name"] == "ocp-test"].empty)
-        self.assertTrue(data["Manager (PI)"].tolist() == billable_pis)
+        assert data[data["Manager (PI)"].isin(nonbillable_pis)].empty
+        assert data[data["Project - Allocation"].isin(nonbillable_projects)].empty
+        assert data[data["Cluster Name"] == "ocp-test"].empty
+        assert data["Manager (PI)"].tolist() == billable_pis
 
     def test_empty_pi_name(self):
         test_data = pandas.DataFrame(
@@ -55,11 +53,11 @@ class TestValidateBillablePIProcessor(TestCase):
                 "Cluster Name": ["test-cluster"] * 5,
             }
         )
-        self.assertEqual(1, len(test_data[pandas.isna(test_data["Manager (PI)"])]))
+        assert len(test_data[pandas.isna(test_data["Manager (PI)"])]) == 1
         validate_billable_pi_proc = test_utils.new_validate_billable_pi_processor(
             data=test_data
         )
         validate_billable_pi_proc.process()
         output_data = validate_billable_pi_proc.data
         output_data = output_data[~output_data["Missing PI"]]
-        self.assertEqual(0, len(output_data[pandas.isna(output_data["Manager (PI)"])]))
+        assert len(output_data[pandas.isna(output_data["Manager (PI)"])]) == 0

--- a/process_report/tests/unit/processors/test_validate_cluster_name_processor.py
+++ b/process_report/tests/unit/processors/test_validate_cluster_name_processor.py
@@ -18,4 +18,4 @@ class TestValidateClusterNameProcessor(TestCase):
         )
         validate_proc.process()
 
-        self.assertTrue(validate_proc.data.equals(answer_invoice))
+        assert validate_proc.data.equals(answer_invoice)

--- a/process_report/tests/unit/test_institute_list_validate.py
+++ b/process_report/tests/unit/test_institute_list_validate.py
@@ -1,4 +1,5 @@
 import yaml
+import pytest
 
 from process_report.institute_list_validate import main
 from process_report.tests.base import BaseTestCaseWithTempDir
@@ -39,5 +40,5 @@ class TestInstituteListValidate(BaseTestCaseWithTempDir):
         with open(test_file, "w") as f:
             yaml.dump(test_institute_list, f)
             f.flush()
-            with self.assertRaises(SystemExit):
+            with pytest.raises(SystemExit):
                 main(["--github", str(test_file)])

--- a/process_report/tests/unit/test_util.py
+++ b/process_report/tests/unit/test_util.py
@@ -3,6 +3,7 @@ import tempfile
 import pandas
 import os
 from textwrap import dedent
+import pytest
 
 from process_report import process_report, util
 
@@ -16,8 +17,8 @@ class TestMonthUtils(TestCase):
             (("2024-12", "2025-03"), -3),
         ]
         for arglist, answer in testcases:
-            self.assertEqual(util.get_month_diff(*arglist), answer)
-        with self.assertRaises(ValueError):
+            assert util.get_month_diff(*arglist) == answer
+        with pytest.raises(ValueError):
             util.get_month_diff("2024-16", "2025-03")
 
 
@@ -51,12 +52,12 @@ class TestMergeCSV(TestCase):
         )
 
         expected_rows = len(self.data) * 3
-        self.assertEqual(
-            len(merged_dataframe), expected_rows
-        )  # `len` for a pandas dataframe excludes the header row
+
+        # `len` for a pandas dataframe excludes the header row
+        assert len(merged_dataframe) == expected_rows
 
         # Assert that the headers in the merged DataFrame match the expected headers
-        self.assertListEqual(merged_dataframe.columns.tolist(), self.header)
+        assert merged_dataframe.columns.tolist() == self.header
 
 
 class TestTimedProjects(TestCase):
@@ -88,7 +89,7 @@ class TestTimedProjects(TestCase):
         )
 
         expected_projects = ["ProjectB", "ProjectC", "ProjectD"]
-        self.assertEqual(excluded_projects, expected_projects)
+        assert excluded_projects == expected_projects
 
 
 class TestValidateRequiredEnvVars(TestCase):
@@ -102,7 +103,7 @@ class TestValidateRequiredEnvVars(TestCase):
 
     @mock.patch.dict("os.environ", {"KEYCLOAK_CLIENT_ID": "test"})
     def test_env_vars_missing(self):
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             process_report.validate_required_env_vars(
                 ["KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
             )


### PR DESCRIPTION
Closes #220. Update test workflows to use `pytest`

As suggested before[1], `unittest` assertions are now replaced 
with normal asserts to utilize  `pytest`'s better error logging. 
Corresponding changes made to workflows.

[1] https://github.com/CCI-MOC/invoicing/issues/220#issuecomment-3074211605