### PR TITLE
Included H100 into list of excluded SU types for new PI credit processing

### DIFF
--- a/process_report/processors/new_pi_credit_processor.py
+++ b/process_report/processors/new_pi_credit_processor.py
@@ -22,7 +22,12 @@ class NewPICreditProcessor(discount_processor.DiscountProcessor):
     """
 
     NEW_PI_CREDIT_CODE = "0002"
-    EXCLUDE_SU_TYPES = ["OpenShift GPUA100SXM4", "OpenStack GPUA100SXM4"]
+    EXCLUDE_SU_TYPES = [
+        "OpenShift GPUA100SXM4",
+        "OpenStack GPUA100SXM4",
+        "OpenShift GPUH100",
+        "OpenStack GPUH100",
+    ]
     IS_DISCOUNT_BY_NERC = True
 
     old_pi_filepath: str

--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -465,13 +465,13 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
 
         invoice_month = "2024-06"
         test_invoice = self._get_test_invoice(
-            ["PI", "PI", "PI", "PI"],
+            ["PI", "PI", "PI", "PI2"],
             [600, 600, 600, 600],
             [
                 "CPU",
                 "OpenShift GPUA100SXM4",
                 "GPU",
-                "OpenStack GPUA100SXM4",
+                "OpenStack GPUH100",
             ],
         )
         test_old_pi_file = self.tempdir / "old_pi.csv"


### PR DESCRIPTION
A mistake was caught during 2025-09 billing review, where the new PI credit was incorrectly applied to H100 usage. 

I've added the H100 SUs to the list for now. I plan on having a more robust solution for #237 