### PR TITLE
Fixed CI failure

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -105,10 +105,12 @@ def merge_csv(files):
     for file in files:
         dataframe = pandas.read_csv(
             file,
-            dtype={
-                invoice.COST_FIELD: pandas.ArrowDtype(pyarrow.decimal128(12, 2)),
+        )
+        dataframe = dataframe.astype(
+            {
+                invoice.COST_FIELD: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
                 invoice.RATE_FIELD: str,
-            },
+            }
         )
         dataframes.append(dataframe)
 

--- a/process_report/processors/new_pi_credit_processor.py
+++ b/process_report/processors/new_pi_credit_processor.py
@@ -50,7 +50,9 @@ class NewPICreditProcessor(discount_processor.DiscountProcessor):
         try:
             old_pi_df = pandas.read_csv(
                 old_pi_filepath,
-                dtype={
+            )
+            old_pi_df = old_pi_df.astype(
+                {
                     invoice.PI_INITIAL_CREDITS: pandas.ArrowDtype(
                         pyarrow.decimal128(21, 2)
                     ),

--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -1,4 +1,5 @@
 from unittest import TestCase, mock
+from decimal import Decimal
 import pandas
 import pytest
 
@@ -85,7 +86,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         assert output_old_pi_df.equals(answer_old_pi_df)
 
     def _get_test_invoice(
-        self, pi, cost, su_type=None, is_billable=None, missing_pi=None
+        self, pi, costs, su_type=None, is_billable=None, missing_pi=None
     ):
         if not su_type:
             su_type = ["CPU" for _ in range(len(pi))]
@@ -99,7 +100,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         return pandas.DataFrame(
             {
                 "Manager (PI)": pi,
-                "Cost": cost,
+                "Cost": [Decimal(cost) for cost in costs],
                 "SU Type": su_type,
                 "Is Billable": is_billable,
                 "Missing PI": missing_pi,
@@ -119,6 +120,8 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
                 "PI": ["PI"],
                 "First Invoice Month": ["2024-01"],
                 "Initial Credits": [1000],
+                "1st Month Used": [None],
+                "2nd Month Used": [None],
             }
         )
         test_old_pi_df.to_csv(test_old_pi_file, index=False)

--- a/process_report/tests/unit/test_util.py
+++ b/process_report/tests/unit/test_util.py
@@ -26,7 +26,7 @@ class TestMonthUtils(TestCase):
 
 class TestMergeCSV(TestCase):
     def setUp(self):
-        self.header = ["ID", "Name", "Age"]
+        self.header = ["Cost", "Name", "Rate"]
         self.data = [
             [1, "Alice", 25],
             [2, "Bob", 30],


### PR DESCRIPTION
While not entirely clear, it seems the recent Pandas relase (3.0.0) changed how casting to decimal types works, causing some invoicing code to throw errors, specifically calls to `read_csv()`

Seperating loading of the CSV and casting seems to fix this