### PR TITLE
Keep track of PI age even if not eligible for New-PI credit

### DIFF
--- a/process_report/processors/new_pi_credit_processor.py
+++ b/process_report/processors/new_pi_credit_processor.py
@@ -83,6 +83,42 @@ class NewPICreditProcessor(discount_processor.DiscountProcessor):
         else:
             return month_diff
 
+    @staticmethod
+    def _upsert_pi_entry(
+        old_pi_df,
+        pi_name,
+        invoice_month,
+        initial_credits,
+        first_month_used,
+        second_month_used,
+    ) -> pandas.DataFrame:
+        """
+        Upserts PI entry in old PI dataframe.
+
+        If the PI already has an entry, overwrites the entry with new values, otherwise creates a new entry.
+
+        This returns the updated old_pi_df
+        """
+        pi_entry = [
+            pi_name,
+            invoice_month,
+            initial_credits,
+            first_month_used,
+            second_month_used,
+        ]
+        if old_pi_df.loc[old_pi_df[invoice.PI_PI_FIELD] == pi_name].empty:
+            old_pi_df = pandas.concat(
+                [
+                    pandas.DataFrame([pi_entry], columns=old_pi_df.columns),
+                    old_pi_df,
+                ],
+                ignore_index=True,
+            )
+        else:
+            old_pi_df.loc[old_pi_df[invoice.PI_PI_FIELD] == pi_name] = pi_entry
+
+        return old_pi_df
+
     def _filter_partners(self, data):
         active_partnerships = list()
         institute_list = util.load_institute_list()
@@ -114,60 +150,50 @@ class NewPICreditProcessor(discount_processor.DiscountProcessor):
     def _apply_credits_new_pi(
         self, data: pandas.DataFrame, old_pi_df: pandas.DataFrame
     ):
-        def get_initial_credit_amount(
-            old_pi_df, invoice_month, default_initial_credit_amount
-        ):
-            first_month_processed_pis = old_pi_df[
-                old_pi_df[invoice.PI_FIRST_MONTH] == invoice_month
-            ]
-            if first_month_processed_pis[
-                invoice.PI_INITIAL_CREDITS
-            ].empty or pandas.isna(
-                new_pi_credit_amount := first_month_processed_pis[
-                    invoice.PI_INITIAL_CREDITS
-                ].iat[0]
-            ):
-                new_pi_credit_amount = default_initial_credit_amount
-
-            return new_pi_credit_amount
-
-        new_pi_credit_amount = get_initial_credit_amount(
-            old_pi_df, self.invoice_month, self.initial_credit_amount
-        )
         logger.info(
-            f"New PI Credit set at {new_pi_credit_amount} for {self.invoice_month}"
+            f"New PI Credit set at {self.initial_credit_amount} for {self.invoice_month}"
         )
 
         credit_eligible_projects = self._get_credit_eligible_projects(data)
-        current_pi_set = set(credit_eligible_projects[invoice.PI_FIELD])
-        for pi in current_pi_set:
-            pi_projects = credit_eligible_projects[
-                credit_eligible_projects[invoice.PI_FIELD] == pi
-            ]
+        all_pi_set = set(data[~data[invoice.MISSING_PI_FIELD]][invoice.PI_FIELD])
+        eligible_pi_set = set(credit_eligible_projects[invoice.PI_FIELD])
+        for pi in all_pi_set:
             pi_age = self._get_pi_age(old_pi_df, pi, self.invoice_month)
             pi_old_pi_entry = old_pi_df.loc[
                 old_pi_df[invoice.PI_PI_FIELD] == pi
             ].squeeze()
+
+            # If the pi is not eligible, their initial credit amount is set to 0,
+            # but we still want to keep track of them in case they become eligible in the future
+            # More detail: https://github.com/CCI-MOC/invoicing/issues/280
+            if pi not in eligible_pi_set and pi_age == 0:
+                old_pi_df = self._upsert_pi_entry(
+                    old_pi_df, pi, self.invoice_month, 0, 0, 0
+                )
+                continue
+
+            pi_projects = credit_eligible_projects[
+                credit_eligible_projects[invoice.PI_FIELD] == pi
+            ]
 
             if pi_age > 1:
                 for i, row in pi_projects.iterrows():
                     data.at[i, invoice.BALANCE_FIELD] = row[invoice.COST_FIELD]
             else:
                 if pi_age == 0:
-                    if len(pi_old_pi_entry) == 0:
-                        pi_entry = [pi, self.invoice_month, new_pi_credit_amount, 0, 0]
-                        old_pi_df = pandas.concat(
-                            [
-                                pandas.DataFrame([pi_entry], columns=old_pi_df.columns),
-                                old_pi_df,
-                            ],
-                            ignore_index=True,
-                        )
-                        pi_old_pi_entry = old_pi_df.loc[
-                            old_pi_df[invoice.PI_PI_FIELD] == pi
-                        ].squeeze()
+                    old_pi_df = self._upsert_pi_entry(
+                        old_pi_df,
+                        pi,
+                        self.invoice_month,
+                        self.initial_credit_amount,
+                        0,
+                        0,
+                    )
+                    pi_old_pi_entry = old_pi_df.loc[
+                        old_pi_df[invoice.PI_PI_FIELD] == pi
+                    ].squeeze()
 
-                    remaining_credit = new_pi_credit_amount
+                    remaining_credit = self.initial_credit_amount
                     credit_used_field = invoice.PI_1ST_USED
                 elif pi_age == 1:
                     remaining_credit = (

--- a/process_report/tests/e2e/test_data/test_PI.csv
+++ b/process_report/tests/e2e/test_data/test_PI.csv
@@ -1,3 +1,6 @@
 PI,First Invoice Month,Initial Credits,1st Month Used,2nd Month Used
+pi5@harvard.edu,2025-06,0.00,0.00,0.00
+pi6@mit.edu,2025-06,0.00,0.00,0.00
+pi4@example.edu,2025-06,0.00,0.00,0.00
 pi1@bu.edu,2025-04,1000.00,300.00,0.00
 pi2@harvard.edu,2025-04,1000.00,300.00,0.00

--- a/process_report/tests/unit/processors/test_new_pi_credit_processor.py
+++ b/process_report/tests/unit/processors/test_new_pi_credit_processor.py
@@ -65,11 +65,15 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         test_old_pi_filepath,
         answer_invoice,
         answer_old_pi_df,
+        credit_amount=1000,
+        limit_new_pi_credit_to_partners=False,
     ):
         new_pi_credit_proc = test_utils.new_new_pi_credit_processor(
             invoice_month=invoice_month,
             data=test_invoice,
             old_pi_filepath=test_old_pi_filepath,
+            credit_amount=credit_amount,
+            limit_new_pi_credit_to_partners=limit_new_pi_credit_to_partners,
         )
         new_pi_credit_proc.process()
         output_invoice = new_pi_credit_proc.data
@@ -86,7 +90,13 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         assert output_old_pi_df.equals(answer_old_pi_df)
 
     def _get_test_invoice(
-        self, pi, costs, su_type=None, is_billable=None, missing_pi=None
+        self,
+        pi,
+        costs,
+        su_type=None,
+        is_billable=None,
+        missing_pi=None,
+        institution=None,
     ):
         if not su_type:
             su_type = ["CPU" for _ in range(len(pi))]
@@ -97,6 +107,8 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
         if not missing_pi:
             missing_pi = [False for _ in range(len(pi))]
 
+        if not institution:
+            institution = ["Foo University" for _ in range(len(pi))]
         return pandas.DataFrame(
             {
                 "Manager (PI)": pi,
@@ -104,6 +116,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
                 "SU Type": su_type,
                 "Is Billable": is_billable,
                 "Missing PI": missing_pi,
+                "Institution": institution,
             }
         )
 
@@ -414,7 +427,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
 
     def test_old_pi_file_overwritten(self):
         """If PI already has entry in Old PI file,
-        their initial credits and PI entry could be overwritten"""
+        their initial credits and PI entry could be overwritten if intial credit amount changes"""
 
         invoice_month = "2024-06"
         test_invoice = self._get_test_invoice(["PI", "PI"], [500, 500])
@@ -424,7 +437,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
                 "PI": ["PI"],
                 "First Invoice Month": ["2024-06"],
                 "Initial Credits": [500],
-                "1st Month Used": [200],
+                "1st Month Used": [400],
                 "2nd Month Used": [0],
             }
         )
@@ -435,10 +448,10 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
                 test_invoice,
                 pandas.DataFrame(
                     {
-                        "Credit": [500, None],
+                        "Credit": [200, None],
                         "Credit Code": ["0002", None],
-                        "PI Balance": [0, 500],
-                        "Balance": [0, 500],
+                        "PI Balance": [300, 500],
+                        "Balance": [300, 500],
                     }
                 ),
             ],
@@ -449,8 +462,10 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
             {
                 "PI": ["PI"],
                 "First Invoice Month": ["2024-06"],
-                "Initial Credits": [500],
-                "1st Month Used": [500],
+                "Initial Credits": [
+                    200
+                ],  # Initial credit amount is updated to new credit amount (from 500 to 200)
+                "1st Month Used": [200],
                 "2nd Month Used": [0],
             }
         )
@@ -461,6 +476,7 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
             str(test_old_pi_file),
             answer_invoice,
             answer_old_pi_df,
+            credit_amount=200,  # Test that old PI entry is overwritten with new initial credit amount
         )
 
     def test_excluded_su_types(self):
@@ -504,13 +520,122 @@ class TestNewPICreditProcessor(BaseTestCaseWithTempDir):
             axis=1,
         )
 
+        # PI2 was not eligible for credit, so should only get 0 initial credits
+        answer_old_pi_df = pandas.DataFrame(
+            {
+                "PI": ["PI", "PI2"],
+                "First Invoice Month": ["2024-06", "2024-06"],
+                "Initial Credits": [1000, 0],
+                "1st Month Used": [1000, 0],
+                "2nd Month Used": [0, 0],
+            }
+        )
+
+        self._assert_result_invoice_and_old_pi_file(
+            invoice_month,
+            test_invoice,
+            str(test_old_pi_file),
+            answer_invoice,
+            answer_old_pi_df,
+        )
+
+    def test_ineligible_pi_existing_old_pi_entry(self):
+        """If PI is eligible in first month, but ineligible in second month, do not benefit from credit during second month"""
+
+        invoice_month = "2024-07"
+        test_invoice = self._get_test_invoice(
+            ["PI"], [500], institution=["Foo"]
+        )  # Ineligible institution
+        test_old_pi_file = self.tempdir / "old_pi.csv"
+        test_old_pi_df = pandas.DataFrame(
+            {
+                "PI": ["PI"],
+                "First Invoice Month": ["2024-06"],
+                "Initial Credits": [1000],
+                "1st Month Used": [500],  # Still has 500 credits left
+                "2nd Month Used": [0],
+            }
+        )
+        test_old_pi_df.to_csv(test_old_pi_file, index=False)
+
+        answer_invoice = pandas.concat(
+            [
+                test_invoice,
+                pandas.DataFrame(
+                    {
+                        "Credit": [None],
+                        "Credit Code": [None],
+                        "PI Balance": [500],
+                        "Balance": [500],
+                    }
+                ),
+            ],
+            axis=1,
+        )
+
         answer_old_pi_df = pandas.DataFrame(
             {
                 "PI": ["PI"],
                 "First Invoice Month": ["2024-06"],
                 "Initial Credits": [1000],
-                "1st Month Used": [1000],
+                "1st Month Used": [500],
+                "2nd Month Used": [0],  # Doesn't receive credit
+            }
+        )
+
+        self._assert_result_invoice_and_old_pi_file(
+            invoice_month,
+            test_invoice,
+            str(test_old_pi_file),
+            answer_invoice,
+            answer_old_pi_df,
+            limit_new_pi_credit_to_partners=True,  # PI should be ineligible for credit if we limit to partners
+        )
+
+    def test_newly_eligible_pi_existing_old_pi_entry(self):
+        """If PI is ineligible in first month, but eligible in second month, they should still
+        not receive credit during second month since they were not eligible for credit in their first invoice month"""
+
+        invoice_month = "2024-07"
+        test_invoice = self._get_test_invoice(["PI"], [800])  # Eligible institution
+        test_old_pi_file = self.tempdir / "old_pi.csv"
+        test_old_pi_df = pandas.DataFrame(
+            {
+                "PI": ["PI"],
+                "First Invoice Month": ["2024-06"],
+                "Initial Credits": [
+                    0
+                ],  # Was ineligible in first month, so got 0 credits
+                "1st Month Used": [0],
                 "2nd Month Used": [0],
+            }
+        )
+        test_old_pi_df.to_csv(test_old_pi_file, index=False)
+
+        answer_invoice = pandas.concat(
+            [
+                test_invoice,
+                pandas.DataFrame(
+                    {
+                        "Credit": [None],
+                        "Credit Code": [None],
+                        "PI Balance": [800],
+                        "Balance": [800],
+                    }
+                ),
+            ],
+            axis=1,
+        )
+
+        answer_old_pi_df = pandas.DataFrame(
+            {
+                "PI": ["PI"],
+                "First Invoice Month": ["2024-06"],
+                "Initial Credits": [
+                    0
+                ],  # Still has 0 initial credits since they were ineligible in their first invoice month
+                "1st Month Used": [0],
+                "2nd Month Used": [0],  # Doesn't receive credit
             }
         )
 


### PR DESCRIPTION
Closes #280. This change was needed because recently, we disabled one of the rules for New-PI credit, which allowed a number of PIs to become eligible for the credit. These PIs had used the MOCA for a long time (high PI "age"), so they still received the credit when the rule was disabled. This was considered undesirable, hence the motivation for this change.

Instead of not being registered in the Old PI file at all, ineligible users will receive $0 in credit.