### PR TITLE
Add unit tests for MOCAPrepaidInvoice

### DIFF
--- a/process_report/tests/unit/invoices/test_moca_prepaid_invoice.py
+++ b/process_report/tests/unit/invoices/test_moca_prepaid_invoice.py
@@ -1,0 +1,36 @@
+from unittest import TestCase, mock
+import pandas
+
+from process_report.tests import util as test_utils
+
+
+class TestMocaPrepaidInvoice(TestCase):
+    def _get_test_data(self, group_managed):
+        return pandas.DataFrame({"MGHPCC Managed": group_managed})
+
+    def test_prepare_export(self):
+        test_data = self._get_test_data(group_managed=[True, False, True])
+        inv = test_utils.new_moca_prepaid_invoice(data=test_data)
+        inv._prepare_export()
+        assert len(inv.export_data) == 1
+        assert not inv.export_data.iloc[0]["MGHPCC Managed"]
+
+    def test_output_path(self):
+        inv = test_utils.new_moca_prepaid_invoice(invoice_month="2025-01")
+        assert inv.output_path == "MOCA-A_Prepaid_Groups-2025-01-Invoice.csv"
+
+    def test_output_s3_key(self):
+        inv = test_utils.new_moca_prepaid_invoice(invoice_month="2025-01")
+        assert (
+            inv.output_s3_key
+            == "Invoices/2025-01/MOCA-A_Prepaid_Groups-2025-01-Invoice.csv"
+        )
+
+    @mock.patch("process_report.util.get_iso8601_time")
+    def test_output_s3_archive_key(self, mock_get_time):
+        mock_get_time.return_value = "2025-01-01T00:00:00"
+        inv = test_utils.new_moca_prepaid_invoice(invoice_month="2025-01")
+        assert (
+            inv.output_s3_archive_key
+            == "Invoices/2025-01/Archive/MOCA-A_Prepaid_Groups-2025-01-Invoice 2025-01-01T00:00:00.csv"
+        )

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -5,6 +5,7 @@ from process_report.invoices import (
     pi_specific_invoice,
     prepay_credits_snapshot,
     NERC_total_invoice,
+    MOCA_prepaid_invoice,
 )
 
 from process_report.processors import (
@@ -204,4 +205,16 @@ def new_validate_cluster_name_processor(
 ):
     return validate_cluster_name_processor.ValidateClusterNameProcessor(
         invoice_month, data, name
+    )
+
+
+def new_moca_prepaid_invoice(
+    name="",
+    invoice_month="0000-00",
+    data=None,
+):
+    return MOCA_prepaid_invoice.MOCAPrepaidInvoice(
+        invoice_month,
+        data,
+        name,
     )


### PR DESCRIPTION
part of CCI-MOC/MOC-issues#147 

Adds unit tests for `MOCAPrepaidInvoice`, bringing coverage from 73% to 100%.

Tests Added:
1. `test_prepare_export` : verifies that only rows where MGHPCC Managed is False are included in the export
2. `test_output_path` : verifies the output filename is correctly formatted with the invoice month
3. `test_output_s3_key` : verifies the S3 path is correctly formatted 
4. `test_output_s3_archive_key` : verifies the S3 archive path is correctly formatted 

Also adds `new_moca_prepaid_invoice()` to tests/util.py to follow the existing pattern used by all other invoices.