### PR TITLE
Use coverage to measure code coverage in unit and e2e tests

### DIFF
--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -1,0 +1,3 @@
+[run]
+parallel = true
+patch = ["subprocess"]

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Run E2E Tests
       run: |
-        pytest process_report/tests/e2e/test_e2e_pipeline.py -v -s --log-cli-level=INFO
+        coverage run --source="." -m pytest process_report/tests/e2e/test_e2e_pipeline.py -v -s --log-cli-level=INFO
+        coverage combine
+        coverage html --fail-under=85 --omit "process_report/tests/**,process_report/util.py,process_report/institute_list_validate.py"
       env:
         CHROME_BIN_PATH: '/usr/bin/chromium'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,4 +23,6 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python -m pytest process_report/tests/unit
+          coverage run --source="." -m pytest process_report/tests/unit
+          coverage combine
+          coverage html --fail-under=80 --omit "process_report/tests/**"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !process_report/tests/e2e/test_data/test_invoices/*.csv
 __pycache__/
 *.py[cod]
+.coverage

--- a/process_report/tests/test-requirements.txt
+++ b/process_report/tests/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest
+coverage


### PR DESCRIPTION
As part of CCI-MOC/MOC-issues#147. I've added usage of `coverage` with minimum coverage goals. I expect these goals to be increased after we merge in the unit tests that @marcoagonzales007 is writing for the mentioned issue.