### PR TITLE
Add royalty mechanism

### DIFF
--- a/process_report/invoices/invoice.py
+++ b/process_report/invoices/invoice.py
@@ -76,6 +76,7 @@ CREDIT_FIELD = "Credit"
 CREDIT_CODE_FIELD = "Credit Code"
 SUBSIDY_FIELD = "Subsidy"
 BALANCE_FIELD = "Balance"
+ROYALTY_FIELD = "Royalty"
 ###
 
 ### Internally used field names
@@ -86,6 +87,7 @@ PROJECT_NAME_FIELD = "Project"
 GROUP_MANAGED_FIELD = "MGHPCC Managed"
 CLUSTER_NAME_FIELD = "Cluster Name"
 IS_COURSE_FIELD = "Is Course"
+IS_EXTERNALLY_FUNDED_FIELD = "Is Externally Funded"
 ###
 
 ### Initialized Column objects
@@ -142,6 +144,10 @@ CLUSTER_NAME_COLUMN = InvoiceColumn(name=CLUSTER_NAME_FIELD, dtype=STRING_FIELD_
 IS_COURSE_COLUMN = InvoiceColumn(
     name=IS_COURSE_FIELD, dtype=BOOL_FIELD_TYPE, default_value=False
 )
+IS_EXTERNALLY_FUNDED_COLUMN = InvoiceColumn(
+    name=IS_EXTERNALLY_FUNDED_FIELD, dtype=BOOL_FIELD_TYPE, default_value=False
+)
+ROYALTY_COLUMN = InvoiceColumn(name=ROYALTY_FIELD, dtype=BALANCE_FIELD_TYPE)
 ###
 
 

--- a/process_report/invoices/royalty_invoice.py
+++ b/process_report/invoices/royalty_invoice.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+import process_report.invoices.invoice as invoice
+
+
+@dataclass
+class RoyaltyInvoice(invoice.Invoice):
+    name: str = "Royalties"
+    export_columns_list = [
+        invoice.PROJECT_FIELD,
+        invoice.PI_FIELD,
+        invoice.CLUSTER_NAME_FIELD,
+        invoice.INSTITUTION_FIELD,
+        invoice.SU_TYPE_FIELD,
+        invoice.BALANCE_FIELD,
+        invoice.ROYALTY_FIELD,
+    ]
+
+    def _prepare_export(self):
+        self.export_data = self.data[~self.data[invoice.ROYALTY_FIELD].isna()]

--- a/process_report/loader.py
+++ b/process_report/loader.py
@@ -215,5 +215,10 @@ class Loader:
             ].itertuples(index=False, name=None)
         )
 
+    @functools.lru_cache
+    def get_royalty_exempt_institutions_list(self) -> tuple[str]:
+        with open(invoice_settings.royalty_exempt_institutions_filepath) as f:
+            return tuple(f.read().splitlines())
+
 
 loader = Loader()

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -18,6 +18,7 @@ from process_report.invoices import (
     MOCA_prepaid_invoice,
     prepay_credits_snapshot,
     ocp_test_invoice,
+    royalty_invoice,
 )
 from process_report.processors import (
     coldfront_fetch_processor,
@@ -31,6 +32,7 @@ from process_report.processors import (
     bu_subsidy_processor,
     prepayment_processor,
     validate_cluster_name_processor,
+    royalty_processor,
 )
 
 PROCESSING_ORDER = [
@@ -45,6 +47,7 @@ PROCESSING_ORDER = [
     new_pi_credit_processor.NewPICreditProcessor,
     bu_subsidy_processor.BUSubsidyProcessor,
     prepayment_processor.PrepaymentProcessor,
+    royalty_processor.RoyaltyProcessor,
 ]
 
 
@@ -97,6 +100,7 @@ def main():
             MOCA_prepaid_invoice.MOCAPrepaidInvoice,
             prepay_credits_snapshot.PrepayCreditsSnapshot,
             ocp_test_invoice.OcpTestInvoice,
+            royalty_invoice.RoyaltyInvoice,
         ],
         invoice_settings.upload_to_s3,
     )

--- a/process_report/processors/coldfront_fetch_processor.py
+++ b/process_report/processors/coldfront_fetch_processor.py
@@ -25,6 +25,7 @@ CF_ATTR_ALLOCATED_PROJECT_NAME = "Allocated Project Name"
 CF_ATTR_ALLOCATED_PROJECT_ID = "Allocated Project ID"
 CF_ATTR_INSTITUTION_SPECIFIC_CODE = "Institution-Specific Code"
 CF_ATTR_IS_COURSE = "Is Course?"
+CF_ATTR_IS_EXTERNALLY_FUNDED = "Is Externally Funded"
 
 
 @dataclass
@@ -34,7 +35,10 @@ class ColdfrontFetchProcessor(processor.Processor):
     )
     coldfront_data_filepath: str = invoice_settings.coldfront_api_filepath
 
-    initializes_columns = (invoice.IS_COURSE_COLUMN,)
+    initializes_columns = (
+        invoice.IS_COURSE_COLUMN,
+        invoice.IS_EXTERNALLY_FUNDED_COLUMN,
+    )
     operates_on_columns = (
         *initializes_columns,
         invoice.PROJECT_COLUMN,
@@ -125,12 +129,19 @@ class ColdfrontFetchProcessor(processor.Processor):
                     project_dict["attributes"].get(CF_ATTR_IS_COURSE, "No").lower()
                     == "yes"
                 )
+                is_externally_funded = (
+                    project_dict["project"]["attributes"]
+                    .get(CF_ATTR_IS_EXTERNALLY_FUNDED, "No")
+                    .lower()
+                    == "yes"
+                )
                 allocation_data[(project_id, cluster_name)] = {
                     invoice.PROJECT_FIELD: project_name,
                     invoice.PI_FIELD: pi_name,
                     invoice.INSTITUTION_ID_FIELD: institute_code,
                     invoice.CLUSTER_NAME_FIELD: cluster_name,
                     invoice.IS_COURSE_FIELD: is_course,
+                    invoice.IS_EXTERNALLY_FUNDED_FIELD: is_externally_funded,
                 }
             except KeyError:
                 continue
@@ -164,6 +175,9 @@ class ColdfrontFetchProcessor(processor.Processor):
                 invoice.INSTITUTION_ID_FIELD
             ]
             self.data.loc[mask, invoice.IS_COURSE_FIELD] = data[invoice.IS_COURSE_FIELD]
+            self.data.loc[mask, invoice.IS_EXTERNALLY_FUNDED_FIELD] = data[
+                invoice.IS_EXTERNALLY_FUNDED_FIELD
+            ]
 
     def _process(self):
         api_data = self._get_coldfront_api_data()

--- a/process_report/processors/prepayment_processor.py
+++ b/process_report/processors/prepayment_processor.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO)
 
 @dataclass
 class PrepaymentProcessor(discount_processor.DiscountProcessor):
-    IS_DISCOUNT_BY_NERC = True
+    IS_DISCOUNT_BY_NERC = False
     PREPAY_DEBITS_S3_FILEPATH = "Prepay/prepay_debits.csv"
 
     initializes_columns = (

--- a/process_report/processors/royalty_processor.py
+++ b/process_report/processors/royalty_processor.py
@@ -1,0 +1,44 @@
+from decimal import Decimal
+import logging
+from dataclasses import dataclass, field
+
+from process_report.loader import loader
+from process_report.settings import invoice_settings
+from process_report.invoices import invoice
+from process_report.processors import processor
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass
+class RoyaltyProcessor(processor.Processor):
+    """
+    Given a percentage royalty rate and list of exemept institutions, creates a new `Royalty` column equal to `Balance` * royalty_rate
+    """
+
+    royalty_rate: Decimal = invoice_settings.royalty_rate
+    royalty_exempt_institution_list: tuple[str] = field(
+        default_factory=loader.get_royalty_exempt_institutions_list
+    )
+
+    initializes_columns = (invoice.ROYALTY_COLUMN,)
+    operates_on_columns = (
+        *initializes_columns,
+        invoice.INSTITUTION_COLUMN,
+        invoice.IS_EXTERNALLY_FUNDED_COLUMN,
+        invoice.BALANCE_COLUMN,
+    )
+
+    def _process(self):
+        non_moc_member_mask = ~self.data[invoice.INSTITUTION_FIELD].isin(
+            self.royalty_exempt_institution_list
+        )
+        externally_funded_mask = self.data[invoice.INSTITUTION_FIELD].isin(
+            self.royalty_exempt_institution_list
+        ) & (self.data[invoice.IS_EXTERNALLY_FUNDED_FIELD] == True)  # noqa: E712
+
+        self.data[invoice.ROYALTY_FIELD] = (
+            self.data[invoice.BALANCE_FIELD] * self.royalty_rate
+        ).where(non_moc_member_mask | externally_funded_mask)

--- a/process_report/settings.py
+++ b/process_report/settings.py
@@ -30,6 +30,10 @@ class Settings(BaseSettings):
     prepay_credits_filepath: str = "prepaid_credits.csv"
     prepay_contacts_filepath: str = "prepaid_contacts.csv"
 
+    # Royalty configuration
+    royalty_rate: Decimal = Decimal("0.00")
+    royalty_exempt_institutions_filepath: str = "royalty_exempt_institutions.txt"
+
     # nerc_rates info
     new_pi_credit_amount: Decimal | None = None
     limit_new_pi_credit_to_partners: bool | None = None

--- a/process_report/tests/base.py
+++ b/process_report/tests/base.py
@@ -43,6 +43,8 @@ FIELD_DTYPES = {
     "MGHPCC Managed": BOOL_FIELD_TYPE,
     "Cluster Name": STRING_FIELD_TYPE,
     "Is Course": BOOL_FIELD_TYPE,
+    "Is Externally Funded": BOOL_FIELD_TYPE,
+    "Royalty": BALANCE_FIELD_TYPE,
 }
 
 

--- a/process_report/tests/e2e/test_data/test_coldfront_api_data.json
+++ b/process_report/tests/e2e/test_data/test_coldfront_api_data.json
@@ -2,7 +2,10 @@
     {
         "id": 1,
         "project": {
-            "pi": "pi1@bu.edu"
+            "pi": "pi1@bu.edu",
+            "attributes": {
+                "Is Externally Funded": "Yes"
+            }
         },
         "resource": {
             "name": "shift"
@@ -15,7 +18,8 @@
     {
         "id": 1,
         "project": {
-            "pi": "pi1@bu.edu"
+            "pi": "pi1@bu.edu",
+            "attributes": {}
         },
         "resource": {
             "name": "shift"
@@ -28,7 +32,8 @@
     {
         "id": 1,
         "project": {
-            "pi": "pi2@harvard.edu"
+            "pi": "pi2@harvard.edu",
+            "attributes": {}
         },
         "resource": {
             "name": "shift"

--- a/process_report/tests/e2e/test_data/test_royalty_exempt_institutions.txt
+++ b/process_report/tests/e2e/test_data/test_royalty_exempt_institutions.txt
@@ -1,0 +1,1 @@
+Boston University

--- a/process_report/tests/e2e/test_e2e_pipeline.py
+++ b/process_report/tests/e2e/test_e2e_pipeline.py
@@ -21,6 +21,7 @@ EXPECTED_CSV_FILES = [
     "MOCA-A_Prepaid_Groups-2025-06-Invoice.csv",
     "NERC_Prepaid_Group-Credits-2025-06.csv",
     "OCP_TEST 2025-06.csv",
+    "Royalties 2025-06.csv",
 ]
 
 EXPECTED_DIRECTORIES = ["pi_invoices"]
@@ -126,6 +127,11 @@ def _prepare_pipeline_execution(
     env["PREPAY_CONTACTS_FILEPATH"] = str(test_files["test_prepay_contacts.csv"])
     env["nonbillable_pis_filepath"] = str(test_files["test_pi.yaml"])
     env["nonbillable_projects_filepath"] = str(test_files["test_projects.yaml"])
+
+    env["ROYALTY_RATE"] = "0.1"
+    env["ROYALTY_EXEMPT_INSTITUTIONS_FILEPATH"] = str(
+        test_files["test_royalty_exempt_institutions.txt"]
+    )
 
     # Fallback ensures test works even when CI environment doesn't set Chrome path
     env.setdefault("CHROME_BIN_PATH", "/usr/bin/chromium")

--- a/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
+++ b/process_report/tests/unit/processors/test_coldfront_fetch_processor.py
@@ -15,6 +15,7 @@ class TestColdfrontFetchProcessor(BaseTestCase):
         institute_code=None,
         cluster_name=None,
         is_course=None,
+        externally_funded=None,
     ):
         if not pi:
             pi = [""] * len(allocation_project_id)
@@ -31,6 +32,9 @@ class TestColdfrontFetchProcessor(BaseTestCase):
         if not is_course:
             is_course = [False] * len(allocation_project_id)
 
+        if not externally_funded:
+            externally_funded = [False] * len(allocation_project_id)
+
         return self.create_test_invoice(
             {
                 "Manager (PI)": pi,
@@ -39,6 +43,7 @@ class TestColdfrontFetchProcessor(BaseTestCase):
                 "Institution - Specific Code": institute_code,
                 "Cluster Name": cluster_name,
                 "Is Course": is_course,
+                "Is Externally Funded": externally_funded,
             }
         )
 
@@ -49,6 +54,7 @@ class TestColdfrontFetchProcessor(BaseTestCase):
         institute_code_list,
         cluster_list,
         is_course_list=None,
+        externally_funded_list=None,
     ):
         mock_data = []
         for i, project in enumerate(project_id_list):
@@ -58,6 +64,7 @@ class TestColdfrontFetchProcessor(BaseTestCase):
                 },
                 "project": {
                     "pi": pi_list[i],
+                    "attributes": {},
                 },
                 "attributes": {
                     "Allocated Project ID": project,
@@ -68,6 +75,11 @@ class TestColdfrontFetchProcessor(BaseTestCase):
 
             if is_course_list:
                 mock_project_dict["attributes"]["Is Course?"] = is_course_list[i]
+
+            if externally_funded_list:
+                mock_project_dict["project"]["attributes"]["Is Externally Funded"] = (
+                    externally_funded_list[i]
+                )
 
             mock_data.append(mock_project_dict)
 
@@ -93,6 +105,7 @@ class TestColdfrontFetchProcessor(BaseTestCase):
             ["IC1", "IC1", "", "", "IC2"],
             ["stack"] * 5,
             is_course=[False] * 5,
+            externally_funded=[False] * 5,
         )
         test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
             data=test_invoice
@@ -223,6 +236,65 @@ class TestColdfrontFetchProcessor(BaseTestCase):
             ["IC1", "IC2", "IC3"],
             ["stack", "stack", "stack"],
             [True, False, True],
+        )
+        test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
+            data=test_invoice
+        )
+        test_coldfront_fetch_proc.process()
+        output_invoice = test_coldfront_fetch_proc.data
+        assert output_invoice.equals(answer_invoice)
+
+    @mock.patch(
+        "process_report.processors.coldfront_fetch_processor.ColdfrontFetchProcessor._fetch_coldfront_allocation_api",
+    )
+    def test_is_externally_funded_default(self, mock_get_allocation_data):
+        """If 'Is Externally Funded' is not set in the API data, default to False"""
+        mock_get_allocation_data.return_value = self._get_mock_allocation_data(
+            ["P1", "P2", "P3"],
+            ["PI1", "PI2", "PI3"],
+            ["IC1", "IC2", "IC3"],
+            ["stack", "stack", "stack"],
+        )
+        test_invoice = self._get_test_invoice(
+            ["P1", "P2", "P3"], cluster_name=["stack", "stack", "stack"]
+        )
+        answer_invoice = self._get_test_invoice(
+            ["P1", "P2", "P3"],
+            ["P1-name", "P2-name", "P3-name"],
+            ["PI1", "PI2", "PI3"],
+            ["IC1", "IC2", "IC3"],
+            ["stack", "stack", "stack"],
+            externally_funded=[False, False, False],
+        )
+        test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
+            data=test_invoice
+        )
+        test_coldfront_fetch_proc.process()
+        output_invoice = test_coldfront_fetch_proc.data
+        assert output_invoice.equals(answer_invoice)
+
+    @mock.patch(
+        "process_report.processors.coldfront_fetch_processor.ColdfrontFetchProcessor._fetch_coldfront_allocation_api",
+    )
+    def test_is_externally_funded_values(self, mock_get_allocation_data):
+        """If 'Is Externally Funded' is set in the API data, the output 'Is Externally Funded' column reflects True/False"""
+        mock_get_allocation_data.return_value = self._get_mock_allocation_data(
+            ["P1", "P2", "P3"],
+            ["PI1", "PI2", "PI3"],
+            ["IC1", "IC2", "IC3"],
+            ["stack", "stack", "stack"],
+            externally_funded_list=["Yes", "No", "yes"],
+        )
+        test_invoice = self._get_test_invoice(
+            ["P1", "P2", "P3"], cluster_name=["stack", "stack", "stack"]
+        )
+        answer_invoice = self._get_test_invoice(
+            ["P1", "P2", "P3"],
+            ["P1-name", "P2-name", "P3-name"],
+            ["PI1", "PI2", "PI3"],
+            ["IC1", "IC2", "IC3"],
+            ["stack", "stack", "stack"],
+            externally_funded=[True, False, True],
         )
         test_coldfront_fetch_proc = test_utils.new_coldfront_fetch_processor(
             data=test_invoice

--- a/process_report/tests/unit/processors/test_prepayment_processor.py
+++ b/process_report/tests/unit/processors/test_prepayment_processor.py
@@ -1,9 +1,15 @@
+import pytest
+
 import pandas
 
 from process_report.tests import util as test_utils
 from process_report.tests.base import BaseTestCaseWithTempDir
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Royalty processor requires breaking prepayments until refactoring",
+)
 class TestPrepaymentProcessor(BaseTestCaseWithTempDir):
     def _assert_result_invoice(
         self,

--- a/process_report/tests/unit/processors/test_royalty_processor.py
+++ b/process_report/tests/unit/processors/test_royalty_processor.py
@@ -1,0 +1,71 @@
+import unittest
+from decimal import Decimal
+
+import pandas
+
+from process_report.invoices import invoice
+from process_report.tests import util as test_utils
+
+
+class TestRoyaltyProcessor(unittest.TestCase):
+    def _get_test_invoice(
+        self, institutions, balances, externally_funded, royalty=None
+    ):
+        if royalty is None:
+            royalty = [None for _ in range(len(institutions))]
+        return pandas.DataFrame(
+            {
+                invoice.INSTITUTION_FIELD: institutions,
+                invoice.BALANCE_FIELD: balances,
+                invoice.IS_EXTERNALLY_FUNDED_FIELD: externally_funded,
+                invoice.ROYALTY_FIELD: royalty,
+            }
+        )
+
+    def test_non_moc_member_gets_royalty_but_moc_member_does_not(self):
+        test_invoice = self._get_test_invoice(
+            institutions=["NonMOC", "MOCMember"],
+            balances=[Decimal("100.00"), Decimal("200.00")],
+            externally_funded=[False, False],
+        )
+
+        answer_invoice = self._get_test_invoice(
+            institutions=["NonMOC", "MOCMember"],
+            balances=[Decimal("100.00"), Decimal("200.00")],
+            externally_funded=[False, False],
+            royalty=[Decimal("10.00"), None],
+        )
+
+        processor = test_utils.new_royalty_processor(
+            invoice_month="2024-01",
+            data=test_invoice,
+            royalty_rate=Decimal("0.10"),
+            institution_list=["MOCMember"],
+        )
+        processor.process()
+
+        assert processor.data.equals(answer_invoice)
+
+    def test_externally_funded_moc_member_gets_royalty(self):
+        test_invoice = self._get_test_invoice(
+            institutions=["ExternallyFundedMOC", "MOCMember"],
+            balances=[Decimal("200.00"), Decimal("150.00")],
+            externally_funded=[True, False],
+        )
+
+        answer_invoice = self._get_test_invoice(
+            institutions=["ExternallyFundedMOC", "MOCMember"],
+            balances=[Decimal("200.00"), Decimal("150.00")],
+            externally_funded=[True, False],
+            royalty=[Decimal("20.00"), None],
+        )
+
+        processor = test_utils.new_royalty_processor(
+            invoice_month="2024-01",
+            data=test_invoice,
+            royalty_rate=Decimal("0.10"),
+            institution_list=["ExternallyFundedMOC", "MOCMember"],
+        )
+        processor.process()
+
+        assert processor.data.equals(answer_invoice)

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pandas
 
 from process_report.invoices import (
@@ -10,6 +12,7 @@ from process_report.invoices import (
 
 from process_report.processors import (
     coldfront_fetch_processor,
+    royalty_processor,
     validate_pi_alias_processor,
     lenovo_processor,
     validate_billable_pi_processor,
@@ -217,4 +220,20 @@ def new_moca_prepaid_invoice(
         invoice_month,
         data,
         name,
+    )
+
+
+def new_royalty_processor(
+    name="",
+    invoice_month="0000-00",
+    data=None,
+    royalty_rate=Decimal("0.00"),
+    institution_list=None,
+):
+    if data is None:
+        data = pandas.DataFrame()
+    if institution_list is None:
+        institution_list = []
+    return royalty_processor.RoyaltyProcessor(
+        invoice_month, data, name, royalty_rate, institution_list
     )


### PR DESCRIPTION
Closes CCI-MOC/MOC-issues#136. I'll set this as draft, as I have some questions.

This involved several changes:
- New field `moc_member` in institution list
- New pipeline setting `royalty_rate`, default to fetching from nerc_rates
- Coldfront processor will now obtain info on whether a project is externally funded from Coldfront API
- New processor and invoice to calculate and export the royalties