### PR TITLE
Increase e2e coverage for NewPICredit and Prepayment processors

### DIFF
--- a/process_report/tests/e2e/test_data/test_PI.csv
+++ b/process_report/tests/e2e/test_data/test_PI.csv
@@ -2,5 +2,6 @@ PI,First Invoice Month,Initial Credits,1st Month Used,2nd Month Used
 pi5@harvard.edu,2025-06,0.00,0.00,0.00
 pi6@mit.edu,2025-06,0.00,0.00,0.00
 pi4@example.edu,2025-06,0.00,0.00,0.00
-pi1@bu.edu,2025-04,1000.00,300.00,0.00
-pi2@harvard.edu,2025-04,1000.00,300.00,0.00
+pi1@bu.edu,2025-06,1000.00,320.00,0.00
+pi2@harvard.edu,2025-05,1000.00,300.00,35.00
+pi7@mit.edu,2025-04,1000.00,1000.00,0.00

--- a/process_report/tests/e2e/test_data/test_coldfront_api_data.json
+++ b/process_report/tests/e2e/test_data/test_coldfront_api_data.json
@@ -37,5 +37,11 @@
             "Allocated Project Name": "P3",
             "Allocated Project ID": "P3ID"
         }
+    },
+    {
+        "id" : 1,
+        "project" : {"pi" : "pi7@mit.edu"},
+        "resource": { "name": "shift" },
+        "attributes": { "Allocated Project Name": "P7", "Allocated Project ID": "P7ID" }
     }
 ]

--- a/process_report/tests/e2e/test_data/test_invoices/test_NERC OpenShift 2025-04.csv
+++ b/process_report/tests/e2e/test_data/test_invoices/test_NERC OpenShift 2025-04.csv
@@ -4,3 +4,4 @@ Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster 
 2024-01,P2ID,P2ID,,shift,,,,,280,OpenShift CPU,0.013,200
 2024-01,P3ID,P3ID,,shift,,,,,280,Free CPU,0.013,300
 2024-01,P9ID,P9ID,,shift,,,,,280,OpenShift CPU,0.013,3000
+2024-01,P7ID,P7ID,,shift,,,,,280,OpenShift CPU,0.013,500

--- a/process_report/tests/e2e/test_data/test_prepay_projects.csv
+++ b/process_report/tests/e2e/test_data/test_prepay_projects.csv
@@ -1,3 +1,3 @@
 Group Name,Project,Start Date,End Date
-TestGroup1,TestProject1,2024-01,2024-12
+TestGroup1,P7,2024-01,2025-12
 TestGroup2,TestProject2,2023-12,2024-06

--- a/process_report/tests/e2e/test_e2e_pipeline.py
+++ b/process_report/tests/e2e/test_e2e_pipeline.py
@@ -117,12 +117,13 @@ def _prepare_pipeline_execution(
     env["FETCH_FROM_S3"] = "false"
     env["UPLOAD_TO_S3"] = "false"
     env["invoice_path_template"] = str(test_files["test_invoice_dir"])
-
-    pi_file_copy = workspace / "test_PI.csv"
+    input_dir = workspace / "input_data"
+    input_dir.mkdir(exist_ok=True)
+    pi_file_copy = input_dir / "test_PI.csv"
     shutil.copy(test_files["test_PI.csv"], pi_file_copy)
     env["PI_REMOTE_FILEPATH"] = str(pi_file_copy)
     env["ALIAS_REMOTE_FILEPATH"] = str(test_files["test_alias.csv"])
-    prepay_debits_copy = workspace / "test_prepay_debits.csv"
+    prepay_debits_copy = input_dir / "test_prepay_debits.csv"
     shutil.copy(test_files["test_prepay_debits.csv"], prepay_debits_copy)
     env["PREPAY_DEBITS_REMOTE_FILEPATH"] = str(prepay_debits_copy)
     env["PREPAY_CREDITS_FILEPATH"] = str(test_files["test_prepay_credits.csv"])

--- a/process_report/tests/e2e/test_e2e_pipeline.py
+++ b/process_report/tests/e2e/test_e2e_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 import pandas as pd
 import pytest
@@ -117,10 +118,13 @@ def _prepare_pipeline_execution(
     env["UPLOAD_TO_S3"] = "false"
     env["invoice_path_template"] = str(test_files["test_invoice_dir"])
 
-    env["PI_REMOTE_FILEPATH"] = str(test_files["test_PI.csv"])
+    pi_file_copy = workspace / "test_PI.csv"
+    shutil.copy(test_files["test_PI.csv"], pi_file_copy)
+    env["PI_REMOTE_FILEPATH"] = str(pi_file_copy)
     env["ALIAS_REMOTE_FILEPATH"] = str(test_files["test_alias.csv"])
-    env["PREPAY_DEBITS_REMOTE_FILEPATH"] = str(test_files["test_prepay_debits.csv"])
-
+    prepay_debits_copy = workspace / "test_prepay_debits.csv"
+    shutil.copy(test_files["test_prepay_debits.csv"], prepay_debits_copy)
+    env["PREPAY_DEBITS_REMOTE_FILEPATH"] = str(prepay_debits_copy)
     env["PREPAY_CREDITS_FILEPATH"] = str(test_files["test_prepay_credits.csv"])
     env["PREPAY_PROJECTS_FILEPATH"] = str(test_files["test_prepay_projects.csv"])
     env["PREPAY_CONTACTS_FILEPATH"] = str(test_files["test_prepay_contacts.csv"])


### PR DESCRIPTION
Part of CCI-MOC/MOC-issues#147 

Updates the e2e test data so the full pipeline covers previously-uncovered branches in the two processors

`NewPICreditProcessor` (80% -> 90%)
- Changed pi1@bu.edu to a "first invoice month" of 2025-06 (age 0) and pi2@harvard.edu to 2025-05 (age 1) in `test_PI.csv`
- This makes both PIs credit eligible within the age window, so the credit-application logic now is able to run

`PrepaymentProcessor` (82% -> 87%)
- Added a dedicated PI (pi7@mit.edu) and project (P7) whose balance survives the subsidy processors, so the prepayment step applies the discount
- Pointed TestGroup1's prepay project at P7 and extended its end date to 2025-12 so it's active for the invoice month
- This covers the active prepay project logic and the debit-recording path that were never reached before