### PR TITLE
Add standard invoice CSV reader/writer

### DIFF
--- a/process_report/invoice_csv.py
+++ b/process_report/invoice_csv.py
@@ -1,0 +1,13 @@
+import csv
+import pandas
+
+QUOTECHAR = "|"
+QUOTING = csv.QUOTE_MINIMAL
+
+
+def write_invoice_csv(df, filepath):
+    df.to_csv(filepath, index=False, quotechar=QUOTECHAR, quoting=QUOTING)
+
+
+def read_invoice_csv(filepath, dtype=None):
+    return pandas.read_csv(filepath, quotechar=QUOTECHAR, dtype=dtype, engine="pyarrow")

--- a/process_report/invoices/invoice.py
+++ b/process_report/invoices/invoice.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pandas
 import pyarrow
 import logging
+from process_report import invoice_csv
 
 import process_report.util as util
 
@@ -225,7 +226,7 @@ class Invoice:
 
     def export(self):
         self._filter_columns()
-        self.export_data.to_csv(self.output_path, index=False)
+        invoice_csv.write_invoice_csv(self.export_data, self.output_path)
 
     def export_s3(self, s3_bucket):
         s3_bucket.upload_file(self.output_path, self.output_s3_key)

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 import pandas
-
+from process_report import invoice_csv
 from process_report.settings import invoice_settings
 from process_report.loader import loader
 from process_report import util
@@ -106,9 +106,8 @@ def merge_csv(files):
     """Merge multiple CSV files and return a single pandas dataframe"""
     dataframes = []
     for file in files:
-        dataframe = pandas.read_csv(
+        dataframe = invoice_csv.read_invoice_csv(
             file,
-            engine="pyarrow",
             dtype={
                 invoice.INVOICE_DATE_COLUMN.name: invoice.INVOICE_DATE_COLUMN.dtype,
                 invoice.PROJECT_COLUMN.name: invoice.PROJECT_COLUMN.dtype,
@@ -124,7 +123,6 @@ def merge_csv(files):
                 invoice.RATE_COLUMN.name: invoice.RATE_COLUMN.dtype,
                 invoice.COST_COLUMN.name: invoice.COST_COLUMN.dtype,
             },
-            quotechar="|",
         )
         dataframes.append(dataframe)
 

--- a/process_report/tests/e2e/test_e2e_pipeline.py
+++ b/process_report/tests/e2e/test_e2e_pipeline.py
@@ -1,10 +1,10 @@
 import os
 from pathlib import Path
-import pandas as pd
 import pytest
 import logging
 import subprocess
 from typing import Dict, List
+from process_report import invoice_csv
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +188,7 @@ def _validate_outputs(workspace: Path) -> None:
         assert csv_path.stat().st_size > 0, f"CSV file is empty: {csv_path}"
 
         try:
-            df = pd.read_csv(csv_path)
+            df = invoice_csv.read_invoice_csv(csv_path)
             assert len(df.columns) > 0, f"CSV has no columns: {csv_path}"
         except Exception as e:
             pytest.fail(f"Failed to read CSV {csv_path}: {e}")

--- a/process_report/tests/unit/test_invoice_csv.py
+++ b/process_report/tests/unit/test_invoice_csv.py
@@ -1,0 +1,37 @@
+import tempfile
+from unittest import TestCase
+
+import pandas
+
+from process_report import invoice_csv
+
+
+class TestInvoiceCSV(TestCase):
+    def _round_trip(self, df):
+        with tempfile.NamedTemporaryFile(suffix=".csv") as f:
+            invoice_csv.write_invoice_csv(df, f.name)
+            return invoice_csv.read_invoice_csv(f.name)
+
+    def test_round_trip_simple(self):
+        test_invoice = pandas.DataFrame(
+            {"Project": ["proj1", "proj2"], "Cost": [100, 200]}
+        )
+        result_invoice = self._round_trip(test_invoice)
+
+        assert result_invoice.equals(test_invoice)
+
+    def test_round_trip_field_with_comma(self):
+        test_invoice = pandas.DataFrame(
+            {"Manager (PI)": ["Green, John"], "Cost": [100]}
+        )
+        result_invoice = self._round_trip(test_invoice)
+
+        assert result_invoice.equals(test_invoice)
+
+    def test_written_file_uses_standard_quotechar(self):
+        test_invoice = pandas.DataFrame({"Manager (PI)": ["Green, John"]})
+        with tempfile.NamedTemporaryFile(suffix=".csv", mode="r+") as f:
+            invoice_csv.write_invoice_csv(test_invoice, f.name)
+            contents = f.read()
+
+        assert "|Green, John|" in contents


### PR DESCRIPTION
Part of CCI-MOC/MOC-issues#139 

Adds a standard reader/writer (`invoice_csv.py`) so all invoice csv's are read and written with one format:

quote character: |
quoting: only fields containing special characters get quoted
read engine: pyarrow

**Changes**: 

1. New `process_report/invoice_csv.py` with `write_invoice_csv()` and `read_invoice_csv()`
2. `Invoice.export()` now writes through the standard writer
3. `merge_csv()` now reads through the standard reader 
4. Unit tests covering round-trip, fields containing commas, and that the standard quote char is actually used 